### PR TITLE
Upgrade to latest fog and bump version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gem 'nokogiri', "= 1.5.10"
+gem 'fog', :git => 'git://github.com/fog/fog.git', :ref => 'dc7c5e285a1a252031d3d1570cbf2289f7137ed0'
 gemspec
 
 group :development do

--- a/lib/vagrant-cloudstack/version.rb
+++ b/lib/vagrant-cloudstack/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Cloudstack
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/vagrant-cloudstack.gemspec
+++ b/vagrant-cloudstack.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-cloudstack"
 
-  s.add_runtime_dependency "fog", "~> 1.10.0"
+  s.add_runtime_dependency "nokogiri", "~> 1.5.10"
+  s.add_runtime_dependency "fog", "~> 1.14.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
Upgrade to latest fog to fix some problems (servers.empty? and deprecation warning mucking up vagrant ssh) but keep nokogiri below 1.5.10 to retain ruby 1.91 compatibility. 
