### PR TITLE
New fog release incorporate fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'nokogiri', "= 1.5.10"
-gem 'fog', :git => 'git://github.com/fog/fog.git', :ref => 'dc7c5e285a1a252031d3d1570cbf2289f7137ed0'
+gem 'fog', '= 1.15.0'
 gemspec
 
 group :development do

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+VERSION=0.0.3
+mkdir -p /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION
+cp -r . /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION/
+tar -C /tmp/vagrant-cloudstack-build_rpm.$$/ -czf ~/rpmbuild/SOURCES/vagrant-cloudstack-$VERSION.tar.gz vagrant-cloudstack-$VERSION
+rpmbuild --define "gemver $VERSION" -bb vagrant-cloudstack.spec
+rm -rf /tmp/vagrant-cloudstack-build_rpm.$$

--- a/vagrant-cloudstack.gemspec
+++ b/vagrant-cloudstack.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "vagrant-cloudstack"
 
   s.add_runtime_dependency "nokogiri", "~> 1.5.10"
-  s.add_runtime_dependency "fog", "~> 1.14.0"
+  s.add_runtime_dependency "fog", "~> 1.15.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"

--- a/vagrant-cloudstack.spec
+++ b/vagrant-cloudstack.spec
@@ -1,0 +1,42 @@
+%define gemdir /usr/lib/vagrant-cloudstack/gems
+Name:	 vagrant-cloudstack
+Version:	%{gemver}
+Release:	3%{?dist}
+Summary:	vagrant cloudstack plugin
+
+License:	MIT
+BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+Source0:        vagrant-cloudstack-%{version}.tar.gz
+BuildRequires:  rubygems 
+Requires:	vagrant >= 1.2.0 libxml2-devel libxslt-devel libffi-devel ruby-devel
+
+%description
+vagrant cloudstack
+
+
+%prep
+%setup -q
+
+%build
+bundle package
+gem build vagrant-cloudstack.gemspec
+
+
+%install
+mkdir -p %{buildroot}/%{gemdir}
+cp vagrant-cloudstack-%{version}.gem %{buildroot}/%{gemdir}
+cp vendor/cache/*.gem %{buildroot}/%{gemdir}
+
+
+%clean
+rm -rf %{buildroot}
+
+
+%post
+cd %{gemdir}
+gem install --local fog --no-rdoc --no-ri
+
+%files
+%defattr(-,root,root,-)
+%{gemdir}


### PR DESCRIPTION
Will work better for the case where gem is pulled in by vagrant plugin install, as it previously required gem of fog to be installed separately.
