### PR TITLE
fix rsync on windows

### DIFF
--- a/lib/vagrant-cloudstack/action/sync_folders.rb
+++ b/lib/vagrant-cloudstack/action/sync_folders.rb
@@ -7,16 +7,16 @@ require "vagrant/util/scoped_hash_override"
 require "vagrant/util/which"
 
 module VagrantPlugins
-  module CloudStack
+  module Cloudstack
     module Action
       # This middleware uses `rsync` to sync the folders over to the
-      # AWS instance.
+      # Cloudstack instance.
       class SyncFolders
         include Vagrant::Util::ScopedHashOverride
 
         def initialize(app, env)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_aws::action::sync_folders")
+          @logger = Log4r::Logger.new("vagrant_cloudstack::action::sync_folders")
         end
 
         def call(env)
@@ -25,13 +25,13 @@ module VagrantPlugins
           ssh_info = env[:machine].ssh_info
 
           env[:machine].config.vm.synced_folders.each do |id, data|
-            data = scoped_hash_override(data, :aws)
+            data = scoped_hash_override(data, :cloudstack)
 
             # Ignore disabled shared folders
             next if data[:disabled]
 
             unless Vagrant::Util::Which.which('rsync')
-              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              env[:ui].warn(I18n.t('vagrant_cloudstack.rsync_not_found_warning'))
               break
             end
 
@@ -47,7 +47,7 @@ module VagrantPlugins
               hostpath = hostpath.gsub(/^(\w):/) { "/cygdrive/#{$1}" }
             end
 
-            env[:ui].info(I18n.t("vagrant_aws.rsync_folder",
+            env[:ui].info(I18n.t("vagrant_cloudstack.rsync_folder",
                                 :hostpath => hostpath,
                                 :guestpath => guestpath))
 

--- a/lib/vagrant-cloudstack/action/sync_folders.rb
+++ b/lib/vagrant-cloudstack/action/sync_folders.rb
@@ -4,17 +4,19 @@ require "vagrant/util/subprocess"
 
 require "vagrant/util/scoped_hash_override"
 
+require "vagrant/util/which"
+
 module VagrantPlugins
-  module Cloudstack
+  module CloudStack
     module Action
       # This middleware uses `rsync` to sync the folders over to the
-      # cloudstack instance.
+      # AWS instance.
       class SyncFolders
         include Vagrant::Util::ScopedHashOverride
 
         def initialize(app, env)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_cloudstack::action::sync_folders")
+          @logger = Log4r::Logger.new("vagrant_aws::action::sync_folders")
         end
 
         def call(env)
@@ -23,10 +25,15 @@ module VagrantPlugins
           ssh_info = env[:machine].ssh_info
 
           env[:machine].config.vm.synced_folders.each do |id, data|
-            data = scoped_hash_override(data, :cloudstack)
+            data = scoped_hash_override(data, :aws)
 
             # Ignore disabled shared folders
             next if data[:disabled]
+
+            unless Vagrant::Util::Which.which('rsync')
+              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              break
+            end
 
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]
@@ -35,7 +42,12 @@ module VagrantPlugins
             # avoid creating an additional directory with rsync
             hostpath = "#{hostpath}/" if hostpath !~ /\/$/
 
-            env[:ui].info(I18n.t("vagrant_cloudstack.rsync_folder",
+            # on windows rsync.exe requires cygdrive-style paths
+            if Vagrant::Util::Platform.windows?
+              hostpath = hostpath.gsub(/^(\w):/) { "/cygdrive/#{$1}" }
+            end
+
+            env[:ui].info(I18n.t("vagrant_aws.rsync_folder",
                                 :hostpath => hostpath,
                                 :guestpath => guestpath))
 
@@ -51,6 +63,12 @@ module VagrantPlugins
               "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
+
+            # we need to fix permissions when using rsync.exe on windows, see
+            # http://stackoverflow.com/questions/5798807/rsync-permission-denied-created-directories-have-no-permissions
+            if Vagrant::Util::Platform.windows?
+              command.insert(1, "--chmod", "ugo=rwX")
+            end
 
             r = Vagrant::Util::Subprocess.execute(*command)
             if r.exit_code != 0

--- a/lib/vagrant-cloudstack/version.rb
+++ b/lib/vagrant-cloudstack/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Cloudstack
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,9 @@ en:
       Instance is not created. Please run `vagrant up` first.
     ready: |-
       Machine is booted and ready for use!
+    rsync_not_found_warning: |-
+      Warning! Folder sync disabled because the rsync binary is missing.
+      Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
     terminating: |-


### PR DESCRIPTION
Fix so the plugin is able to deal with rsync on windows - this was fixed in the AWS plugin this way - https://github.com/mitchellh/vagrant-aws/pull/77/files
