### PR TITLE
Enable to set cloudstack_path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem 'nokogiri', "= 1.5.10"
-gem 'fog', :git => 'git://github.com/fog/fog.git', :ref => 'dc7c5e285a1a252031d3d1570cbf2289f7137ed0'
 gemspec
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Vagrant.configure("2") do |config|
     cloudstack.api_key = "AAAAAAAAAAAAAAAAAAA"
     cloudstack.secret_key = "AAAAAAAAAAAAAAAAAAA"
 
-    cs.template_id = "AAAAAAAAAAAAAAAAAAA"
-    cs.service_offering_id = "AAAAAAAAAAAAAAAAAAA"
-    cs.network_id = "AAAAAAAAAAAAAAAAAAA"
-    cs.zone_id = "AAAAAAAAAAAAAAAAAAA"
-    cs.project_id = "AAAAAAAAAAAAAAAAAAA"
+    cloudstack.template_id = "AAAAAAAAAAAAAAAAAAA"
+    cloudstack.service_offering_id = "AAAAAAAAAAAAAAAAAAA"
+    cloudstack.network_id = "AAAAAAAAAAAAAAAAAAA"
+    cloudstack.zone_id = "AAAAAAAAAAAAAAAAAAA"
+    cloudstack.project_id = "AAAAAAAAAAAAAAAAAAA"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :cloudstack do |cloudstack, override|
     cloudstack.host = "cloudstack.local"
+    cloudstack.path = "/client/api"
     cloudstack.port = "8080"
     cloudstack.scheme = "http"
     cloudstack.api_key = "AAAAAAAAAAAAAAAAAAA"
@@ -90,6 +91,7 @@ provider-specific configuration for this provider.
 This provider exposes quite a few provider-specific configuration options:
 
 * `host` - Cloudstack api host
+* `path` - Cloudstack api path
 * `port` - Cloudstack api port
 * `scheme` - Cloudstack api scheme _(default: http)_
 * `api_key` - The api key for accessing Cloudstack

--- a/lib/vagrant-cloudstack/action/connect_cloudstack.rb
+++ b/lib/vagrant-cloudstack/action/connect_cloudstack.rb
@@ -32,6 +32,7 @@ module VagrantPlugins
           end
 
           fog_config[:cloudstack_host] = domain_config.host if domain_config.host
+          fog_config[:cloudstack_path] = domain_config.path if domain_config.path
           fog_config[:cloudstack_port] = domain_config.port if domain_config.port
           fog_config[:cloudstack_scheme] = domain_config.scheme if domain_config.scheme
 

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -8,6 +8,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :host
 
+      # Cloudstack api path.
+      #
+      # @return [String]
+      attr_accessor :path
+
       # Cloudstack api port.
       #
       # @return [String]
@@ -66,6 +71,7 @@ module VagrantPlugins
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
+        @path                   = UNSET_VALUE
         @port                   = UNSET_VALUE
         @scheme                 = UNSET_VALUE
         @api_key                = UNSET_VALUE
@@ -149,6 +155,9 @@ module VagrantPlugins
       def finalize!
         # Domain_id must be nil, since we can't default that
         @host = nil if @host == UNSET_VALUE
+
+        # Path must be nil, since we can't default that
+        @path = nil if @path == UNSET_VALUE
 
         # Port must be nil, since we can't default that
         @port = nil if @port == UNSET_VALUE

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -16,6 +16,7 @@ describe VagrantPlugins::Cloudstack::Config do
     end
 
     its("host")                   { should be_nil }
+    its("path")                   { should be_nil }
     its("port")                   { should be_nil }
     its("scheme")                 { should == "http" }
     its("api_key")                { should be_nil }
@@ -62,6 +63,7 @@ describe VagrantPlugins::Cloudstack::Config do
 
   describe "domain config" do
     let(:config_host)                   { "foo" }
+    let(:config_path)                   { "foo" }
     let(:config_port)                   { "foo" }
     let(:config_scheme)                 { "foo" }
     let(:config_api_key)                { "foo" }
@@ -76,6 +78,7 @@ describe VagrantPlugins::Cloudstack::Config do
 
     def set_test_values(instance)
       instance.host                   = config_host
+      instance.path                   = config_path
       instance.port                   = config_port
       instance.scheme                 = config_scheme
       instance.api_key                = config_api_key
@@ -107,6 +110,7 @@ describe VagrantPlugins::Cloudstack::Config do
       end
 
       its("host")                   { should == config_host }
+      its("path")                   { should == config_path }
       its("port")                   { should == config_port }
       its("scheme")                 { should == config_scheme }
       its("api_key")                { should == config_api_key }
@@ -137,6 +141,7 @@ describe VagrantPlugins::Cloudstack::Config do
       end
 
       its("host")                   { should == config_host }
+      its("path")                   { should == config_path }
       its("port")                   { should == config_port }
       its("scheme")                 { should == config_scheme }
       its("api_key")                { should == config_api_key }

--- a/vagrant-cloudstack.gemspec
+++ b/vagrant-cloudstack.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-cloudstack"
 
-  s.add_runtime_dependency "nokogiri", "~> 1.5.10"
-  s.add_runtime_dependency "fog", "~> 1.14.0"
+  s.add_runtime_dependency "fog", "~> 1.15.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
Enable to set cloudstack_path to specify the path other than "/client/api".
