### PR TITLE
support for basic zones and keypairs

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -31,6 +31,7 @@ module VagrantPlugins
           project_id          = domain_config.project_id
           service_offering_id = domain_config.service_offering_id
           template_id         = domain_config.template_id
+          keypair             = domain_config.keypair_name
 
           # Launch!
           env[:ui].info(I18n.t("vagrant_cloudstack.launching_instance"))
@@ -39,6 +40,7 @@ module VagrantPlugins
           env[:ui].info(" -- Project UUID: #{project_id}") if project_id != nil
           env[:ui].info(" -- Zone UUID: #{zone_id}")
           env[:ui].info(" -- Network UUID: #{network_id}") if network_id
+          env[:ui].info(" -- Keypair: #{keypair}") if keypair
 
           local_user = ENV['USER'].dup
           local_user.gsub!(/[^-a-z0-9_]/i, "")
@@ -51,11 +53,12 @@ module VagrantPlugins
               :display_name       => display_name,
               :zone_id            => zone_id,
               :flavor_id          => service_offering_id,
-              :image_id           => template_id,
-              :network_ids        => [network_id]
+              :image_id           => template_id
             }
 
-            options['project_id'] = project_id if project_id != nil
+            options['network_ids'] = [network_id] if network_id
+            options['project_id']  = project_id if project_id != nil
+            options['keypair']     = keypair if keypair != nil
 
             server = env[:cloudstack_compute].servers.create(options)
           rescue Fog::Compute::Cloudstack::NotFound => e

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -68,6 +68,12 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :zone_id
+      
+      # Keypair name to use for ssh access.
+      #
+      # @return [String]
+      attr_accessor :keypair_name
+      
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
@@ -83,6 +89,7 @@ module VagrantPlugins
         @service_offering_id    = UNSET_VALUE
         @template_id            = UNSET_VALUE
         @zone_id                = UNSET_VALUE
+        @keypair_name           = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -191,6 +198,9 @@ module VagrantPlugins
 
         # Zone uuid must be nil, since we can't default that
         @zone_id = nil if @zone_id == UNSET_VALUE
+
+        # keypair name must be nil, since we can't default that
+        @keypair_name = nil if @keypair_name == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -28,6 +28,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("service_offering_id")    { should be_nil }
     its("template_id")            { should be_nil }
     its("zone_id")                { should be_nil }
+    its("keypair_name")           { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -37,7 +38,7 @@ describe VagrantPlugins::Cloudstack::Config do
     # and asserts the proper result comes back out.
     [:api_key, :template_id, :zone_id, :instance_ready_timeout,
       :service_offering_id, :api_key,
-      :secret_key, :network_id].each do |attribute|
+      :secret_key, :network_id, :keypair_name].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")
@@ -75,6 +76,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_service_offering_id)    { "foo" }
     let(:config_template_id)            { "foo" }
     let(:config_zone_id)                { "foo" }
+    let(:config_keypair_name)           { "foo" }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -90,6 +92,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.service_offering_id    = config_service_offering_id
       instance.template_id            = config_template_id
       instance.zone_id                = config_zone_id
+      instance.keypair_name           = config_keypair_name
     end
 
     it "should raise an exception if not finalized" do
@@ -122,6 +125,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("service_offering_id")    { should == config_service_offering_id }
       its("template_id")            { should == config_template_id }
       its("zone_id")                { should == config_zone_id }
+      its("keypair_name")           { should == config_keypair_name }
     end
 
     context "with a specific config set" do
@@ -153,6 +157,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("service_offering_id")    { should == config_service_offering_id }
       its("template_id")            { should == config_template_id }
       its("zone_id")                { should == config_zone_id }
+      its("keypair_name")           { should == config_keypair_name }
     end
 
     describe "inheritance of parent config" do


### PR DESCRIPTION
Tested on a basic zone and passing a keypair. 
Need to check that it does not break your advanced zone setup.

in basic zones passing network_ids is not required.
