### PR TITLE
Basic support for Security Groups (Basic Networking)

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -37,6 +37,7 @@ module VagrantPlugins
           pf_ip_address_id    = domain_config.pf_ip_address_id
           pf_public_port      = domain_config.pf_public_port
           pf_private_port     = domain_config.pf_private_port
+          security_group_ids  = domain_config.security_group_ids
 
           # If there is no keypair then warn the user
           if !keypair
@@ -51,6 +52,11 @@ module VagrantPlugins
           env[:ui].info(" -- Zone UUID: #{zone_id}")
           env[:ui].info(" -- Network UUID: #{network_id}") if network_id
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
+          if !security_group_ids.nil?
+            security_group_ids.each do |security_group_id|
+              env[:ui].info(" -- Security Group ID: #{security_group_id}")
+            end
+          end
 
           local_user = ENV['USER'].dup
           local_user.gsub!(/[^-a-z0-9_]/i, "")
@@ -73,7 +79,8 @@ module VagrantPlugins
                 :display_name       => display_name,
                 :zone_id            => zone_id,
                 :flavor_id          => service_offering_id,
-                :image_id           => template_id
+                :image_id           => template_id,
+                :security_group_ids => security_group_ids
               }
             end
 

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -93,6 +93,12 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :pf_private_port
+      
+      # comma separated list of security groups id that going 
+      # to be applied to the virtual machine. 
+      #
+      # @return [Array]
+      attr_accessor :security_group_ids
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
@@ -113,6 +119,7 @@ module VagrantPlugins
         @pf_ip_address_id       = UNSET_VALUE
         @pf_public_port         = UNSET_VALUE
         @pf_private_port        = UNSET_VALUE
+        @security_group_ids     = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -236,6 +243,9 @@ module VagrantPlugins
 
         # Private port must be nil, since we can't default that
         @pf_private_port = nil if @pf_private_port == UNSET_VALUE
+        
+        # Security Group IDs must be nil, since we can't default that
+        @security_group_ids = nil if @security_group_ids == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -32,6 +32,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_ip_address_id")       { should be_nil }
     its("pf_public_port")         { should be_nil }
     its("pf_private_port")        { should be_nil }
+    its("security_group_ids")     { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -83,6 +84,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_ip_address_id)       { "foo" }
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
+    let(:config_security_group_ids)     { ["foo", "bar"] }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -102,6 +104,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_ip_address_id       = config_pf_ip_address_id
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
+      instance.security_group_ids     = config_security_group_ids
     end
 
     it "should raise an exception if not finalized" do
@@ -138,6 +141,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_ip_address_id")       { should == config_pf_ip_address_id }
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
+      its("security_group_ids")     { should == config_security_group_ids }
     end
 
     context "with a specific config set" do
@@ -173,6 +177,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_ip_address_id")       { should == config_pf_ip_address_id }
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
+      its("security_group_ids")     { should == config_security_group_ids }
     end
 
     describe "inheritance of parent config" do


### PR DESCRIPTION
Hi,

I'm trying to use the vagrant-cloudstack plugin with Swiss cloud provider Exoscale (https://www.exoscale.ch/open-cloud/compute/ ) but was missing the ability to specify Security Groups (http://cloudstack.apache.org/docs/en-US/Apache_CloudStack/4.2.0/html/Installation_Guide/security-groups.html)

So I've tried adding this feature, and tested it against Exoscale's Open Cloud. It uses Basic Networking. 

However, I'm not able to test the plugin when using Advanced Networking. 

Let me know what you think...

Nicolas
