### PR TITLE
Added translation for starting state to en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -75,6 +75,12 @@ en:
         not created
       long_not_created: |-
         The instance is not created. Run `vagrant up` to create it.
+
+      short_starting: |-
+        starting
+      long_starting: |-
+        The instance is starting.
+
       short_stopped: |-
         stopped
       long_stopped: |-


### PR DESCRIPTION
Added translation for starting state to en.yml. The translation is missing now.

```
# vagrant status
Current machine states:

default                   translation missing: en.vagrant_cloudstack.states.short_starting (cloudstack)

translation missing: en.vagrant_cloudstack.states.long_starting
```
