### PR TITLE
support for displayname and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `pf_ip_address_id` - IP address ID for port forwarding rule
 * `pf_public_port` - Public port for port forwarding rule
 * `pf_private_port` - Private port for port forwarding rule
+* `display_name` - Display name for the instance
+* `group` - Group for the instance
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -38,14 +38,27 @@ module VagrantPlugins
           pf_public_port      = domain_config.pf_public_port
           pf_private_port     = domain_config.pf_private_port
           security_group_ids  = domain_config.security_group_ids
+          display_name        = domain_config.display_name
+          group               = domain_config.group
 
           # If there is no keypair then warn the user
           if !keypair
             env[:ui].warn(I18n.t("vagrant_cloudstack.launch_no_keypair"))
           end
 
+          if display_name.nil?
+            local_user = ENV['USER'].dup
+            local_user.gsub!(/[^-a-z0-9_]/i, "")
+            prefix = env[:root_path].basename.to_s
+            prefix.gsub!(/[^-a-z0-9_]/i, "")
+            display_name = local_user + "_" + prefix + "_#{Time.now.to_i}"
+          end
+
           # Launch!
           env[:ui].info(I18n.t("vagrant_cloudstack.launching_instance"))
+          env[:ui].info(" -- Display Name: #{display_name}")
+          env[:ui].info(" -- Group: #{group}") if group
+          env[:ui].info(" -- Service offering UUID: #{service_offering_id}")
           env[:ui].info(" -- Service offering UUID: #{service_offering_id}")
           env[:ui].info(" -- Template UUID: #{template_id}")
           env[:ui].info(" -- Project UUID: #{project_id}") if project_id != nil
@@ -58,17 +71,12 @@ module VagrantPlugins
             end
           end
 
-          local_user = ENV['USER'].dup
-          local_user.gsub!(/[^-a-z0-9_]/i, "")
-          prefix = env[:root_path].basename.to_s
-          prefix.gsub!(/[^-a-z0-9_]/i, "")
-          display_name = local_user + "_" + prefix + "_#{Time.now.to_i}"
-
           begin
             case network_type
             when "Advanced"
               options = {
                 :display_name       => display_name,
+                :group              => group,
                 :zone_id            => zone_id,
                 :flavor_id          => service_offering_id,
                 :image_id           => template_id,
@@ -77,6 +85,7 @@ module VagrantPlugins
             when "Basic"
               options = {
                 :display_name       => display_name,
+                :group              => group,
                 :zone_id            => zone_id,
                 :flavor_id          => service_offering_id,
                 :image_id           => template_id,

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -100,6 +100,16 @@ module VagrantPlugins
       # @return [Array]
       attr_accessor :security_group_ids
 
+      # display name for the instance
+      #
+      # @return [String]
+      attr_accessor :display_name
+
+      # group for the instance
+      #
+      # @return [String]
+      attr_accessor :group
+
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
         @path                   = UNSET_VALUE
@@ -120,6 +130,8 @@ module VagrantPlugins
         @pf_public_port         = UNSET_VALUE
         @pf_private_port        = UNSET_VALUE
         @security_group_ids     = UNSET_VALUE
+        @display_name           = UNSET_VALUE
+        @group                  = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -246,6 +258,12 @@ module VagrantPlugins
         
         # Security Group IDs must be nil, since we can't default that
         @security_group_ids = nil if @security_group_ids == UNSET_VALUE
+
+        # Display name must be nil, since we can't default that
+        @display_name = nil if @display_name == UNSET_VALUE
+
+        # Group must be nil, since we can't default that
+        @group = nil if @group == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -33,6 +33,8 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_public_port")         { should be_nil }
     its("pf_private_port")        { should be_nil }
     its("security_group_ids")     { should be_nil }
+    its("display_name")           { should be_nil }
+    its("group")                  { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -85,6 +87,8 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
     let(:config_security_group_ids)     { ["foo", "bar"] }
+    let(:config_display_name)           { "foo" }
+    let(:config_group)                  { "foo" }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -105,6 +109,8 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
       instance.security_group_ids     = config_security_group_ids
+      instance.display_name           = config_display_name
+      instance.group                  = config_group
     end
 
     it "should raise an exception if not finalized" do
@@ -142,6 +148,8 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("display_name")           { should == config_display_name }
+      its("group")                  { should == config_group }
     end
 
     context "with a specific config set" do
@@ -178,6 +186,8 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("display_name")           { should == config_display_name }
+      its("group")                  { should == config_group }
     end
 
     describe "inheritance of parent config" do


### PR DESCRIPTION
Enable to specify display_name and group.
These options are useful if one account is shared by multiple users.

Please review it. 
