### PR TITLE
[Basic Networking] existing Security Groups can be accessed by name

### DIFF
--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -99,6 +99,12 @@ module VagrantPlugins
       #
       # @return [Array]
       attr_accessor :security_group_ids
+      
+      # comma separated list of security groups name that going 
+      # to be applied to the virtual machine. 
+      #
+      # @return [Array]
+      attr_accessor :security_group_names
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
@@ -120,6 +126,7 @@ module VagrantPlugins
         @pf_public_port         = UNSET_VALUE
         @pf_private_port        = UNSET_VALUE
         @security_group_ids     = UNSET_VALUE
+        @security_group_names   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -246,6 +253,9 @@ module VagrantPlugins
         
         # Security Group IDs must be nil, since we can't default that
         @security_group_ids = nil if @security_group_ids == UNSET_VALUE
+        
+        # Security Group Names must be nil, since we can't default that
+        @security_group_names = nil if @security_group_names == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -33,6 +33,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_public_port")         { should be_nil }
     its("pf_private_port")        { should be_nil }
     its("security_group_ids")     { should be_nil }
+    its("security_group_names")   { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -85,6 +86,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
     let(:config_security_group_ids)     { ["foo", "bar"] }
+    let(:config_security_group_names)   { ["foo", "bar"] }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -105,6 +107,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
       instance.security_group_ids     = config_security_group_ids
+      instance.security_group_names   = config_security_group_names
     end
 
     it "should raise an exception if not finalized" do
@@ -142,6 +145,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("security_group_names")   { should == config_security_group_names }
     end
 
     context "with a specific config set" do
@@ -178,6 +182,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("security_group_names")   { should == config_security_group_names }
     end
 
     describe "inheritance of parent config" do


### PR DESCRIPTION
Added support for accessing existing Security Groups by name. As with Security Groups IDs, the Security Groups must have been created before using them in the Vagrantfile, it will fail otherwise.
