### PR TITLE
[Basic Networking] New Security Groups can be created from Vagrantfile

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -39,6 +39,7 @@ module VagrantPlugins
           pf_private_port       = domain_config.pf_private_port
           security_group_ids    = domain_config.security_group_ids
           security_group_names  = domain_config.security_group_names
+          security_groups       = domain_config.security_groups
           
           # If there is no keypair then warn the user
           if !keypair
@@ -47,11 +48,23 @@ module VagrantPlugins
           
           # Can't use Security Group IDs and Names at the same time
           # Let's use IDs by default...
-          if !security_group_ids.nil? && !security_group_names.nil?
-            env[:ui].warn("Security Group Names won't be used since Security Group IDs are declared")
-            security_group_names = nil
+          if !security_group_ids.nil?
+            if !security_group_names.nil?
+              env[:ui].warn("Security Group Names won't be used since Security Group IDs are declared")
+              security_group_names = nil
+            end
+            
+            if !security_groups.nil?
+              env[:ui].warn("Security Groups defined in Vagrantfile won't be used since Security Group IDs are declared")
+              security_groups = nil
+            end
+          else # security_group_ids is nil
+            if !security_group_names.nil? && !security_groups.nil?
+              env[:ui].warn("Security Groups defined in Vagrantfile won't be used since Security Group Names are declared")
+              security_groups = nil
+            end
           end
-
+          
           # Launch!
           env[:ui].info(I18n.t("vagrant_cloudstack.launching_instance"))
           env[:ui].info(" -- Service offering UUID: #{service_offering_id}")
@@ -75,6 +88,56 @@ module VagrantPlugins
               security_group_ids.push(sg[0]["id"])
             end
           end
+          
+          if !security_groups.nil? && security_group_names.nil? && security_group_ids.nil?
+            security_group_ids = []
+            security_groups.each do |sg|
+              # Creating the security group and retrieving it's ID
+              sgid = nil
+              begin
+                sgid = env[:cloudstack_compute].create_security_group(:name => sg[:name], 
+                                                                      :description => sg[:description])["createsecuritygroupresponse"]["securitygroup"]["id"]
+                env[:ui].info(" -- Security Group #{sg[:name]} created with ID: #{sgid}")
+              rescue Exception => e
+                if e.message =~ /already exis/
+                  existingGroup = env[:cloudstack_compute].list_security_groups["listsecuritygroupsresponse"]["securitygroup"].select {|secgrp| secgrp["name"] == sg[:name] }
+                  sgid = existingGroup[0]["id"]
+                  env[:ui].info(" -- Security Group #{sg[:name]} found with ID: #{sgid}")
+                end
+              end
+              
+              # security group is created and we have it's ID            
+              # so we add the rules... Does it really matter if they already exist ? CLoudstack seems to take care of that!
+              sg[:rules].each do |rule|
+                case rule[:type]
+                when "ingress"
+                  env[:cloudstack_compute].authorize_security_group_ingress(:securityGroupId => sgid, 
+                                                                            :protocol => rule[:protocol], 
+                                                                            :startport => rule[:startport], 
+                                                                            :endport => rule[:endport], 
+                                                                            :cidrlist => rule[:cidrlist])
+                  env[:ui].info(" --- Ingress Rule added: #{rule[:protocol]} from #{rule[:startport]} to #{rule[:endport]} (#{rule[:cidrlist]})")
+                when "egress"
+                  env[:cloudstack_compute].authorize_security_group_egress(:securityGroupId => sgid, 
+                                                                           :protocol => rule[:protocol], 
+                                                                           :startport => rule[:startport], 
+                                                                           :endport => rule[:endport], 
+                                                                           :cidrlist => rule[:cidrlist])
+                  env[:ui].info(" --- Egress Rule added: #{rule[:protocol]} from #{rule[:startport]} to #{rule[:endport]} (#{rule[:cidrlist]})")
+                end
+              end
+              
+              # We want to use the Security groups we created
+              security_group_ids.push(sgid)
+              
+              # and record the security group ids for future deletion (of rules and groups if possible)
+              security_groups_file = env[:machine].data_dir.join('security_groups')
+              security_groups_file.open('a+') do |f|
+                f.write("#{sgid}\n")
+              end
+            end
+          end
+          
 
           local_user = ENV['USER'].dup
           local_user.gsub!(/[^-a-z0-9_]/i, "")

--- a/lib/vagrant-cloudstack/action/terminate_instance.rb
+++ b/lib/vagrant-cloudstack/action/terminate_instance.rb
@@ -35,7 +35,51 @@ module VagrantPlugins
           # Destroy the server and remove the tracking ID
           server = env[:cloudstack_compute].servers.get(env[:machine].id)
           env[:ui].info(I18n.t("vagrant_cloudstack.terminating"))
-          server.destroy
+          
+          job = server.destroy
+          while true
+            response = env[:cloudstack_compute].query_async_job_result({:jobid => job.id})
+            if response["queryasyncjobresultresponse"]["jobstatus"] != 0
+              break
+            else
+              env[:ui].info("Waiting for instance to be deleted")
+              sleep 2
+            end
+          end
+          
+          security_groups_file = env[:machine].data_dir.join("security_groups")
+          if security_groups_file.file?
+            File.open(security_groups_file, "r").each_line do |line|
+              security_group_id = line.strip
+              begin
+                security_group = env[:cloudstack_compute].security_groups.get(security_group_id)
+                
+                security_group.ingress_rules.each do |ir|
+                  env[:cloudstack_compute].revoke_security_group_ingress({:id => ir["ruleid"]})
+                end
+                env[:ui].info("Deleted ingress rules")
+    
+                security_group.egress_rules.each do |er|
+                  env[:cloudstack_compute].revoke_security_group_egress({:id => er["ruleid"]})
+                end
+                env[:ui].info("Deleted egress rules")
+                
+              rescue Fog::Compute::Cloudstack::Error => e
+                raise Errors::FogError, :message => e.message
+              end
+              
+              begin
+                env[:cloudstack_compute].delete_security_group({:id => security_group_id})
+              rescue Fog::Compute::Cloudstack::Error => e
+                env[:ui].warn("Couldn't delete group right now.")
+                env[:ui].warn("Waiting 30 seconds to retry")
+                sleep 30
+                retry
+              end
+            end
+            security_groups_file.delete
+          end
+          
           env[:machine].id = nil
 
           @app.call(env)

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -105,6 +105,13 @@ module VagrantPlugins
       #
       # @return [Array]
       attr_accessor :security_group_names
+      
+      # comma separated list of security groups 
+      # (hash with ingress/egress rules)
+      # to be applied to the virtual machine. 
+      #
+      # @return [Array]
+      attr_accessor :security_groups
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
@@ -127,6 +134,7 @@ module VagrantPlugins
         @pf_private_port        = UNSET_VALUE
         @security_group_ids     = UNSET_VALUE
         @security_group_names   = UNSET_VALUE
+        @security_groups        = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -256,6 +264,9 @@ module VagrantPlugins
         
         # Security Group Names must be nil, since we can't default that
         @security_group_names = nil if @security_group_names == UNSET_VALUE
+        
+        # Security Groups must be nil, since we can't default that
+        @security_groups = nil if @security_groups == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -99,6 +99,12 @@ module VagrantPlugins
       #
       # @return [Array]
       attr_accessor :security_group_ids
+      
+      # comma separated list of security groups name that going 
+      # to be applied to the virtual machine. 
+      #
+      # @return [Array]
+      attr_accessor :security_group_names
 
       def initialize(domain_specific=false)
         @host                   = UNSET_VALUE
@@ -120,6 +126,7 @@ module VagrantPlugins
         @pf_public_port         = UNSET_VALUE
         @pf_private_port        = UNSET_VALUE
         @security_group_ids     = UNSET_VALUE
+        @security_group_names   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -246,6 +253,9 @@ module VagrantPlugins
         
         # Security Group IDs must be nil, since we can't default that
         @security_group_ids = nil if @security_group_ids == UNSET_VALUE
+        
+        # Security Group Names must be nil, since we can't default that
+        @security_group_names = nil if @security_group_names == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -33,6 +33,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_public_port")         { should be_nil }
     its("pf_private_port")        { should be_nil }
     its("security_group_ids")     { should be_nil }
+    its("security_group_names")   { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -85,6 +86,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
     let(:config_security_group_ids)     { ["foo", "bar"] }
+    let(:config_security_group_names)   { ["foo", "bar"] }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -105,6 +107,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
       instance.security_group_ids     = config_security_group_ids
+      instance.security_group_names   = config_security_group_names
     end
 
     it "should raise an exception if not finalized" do
@@ -142,6 +145,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("security_group_names")   { should == config_security_group_names }
     end
 
     context "with a specific config set" do
@@ -178,6 +182,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
+      its("security_group_names")   { should == config_security_group_names }
     end
 
     describe "inheritance of parent config" do

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -34,6 +34,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_private_port")        { should be_nil }
     its("security_group_ids")     { should be_nil }
     its("security_group_names")   { should be_nil }
+    its("security_groups")        { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -87,6 +88,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_private_port)        { "foo" }
     let(:config_security_group_ids)     { ["foo", "bar"] }
     let(:config_security_group_names)   { ["foo", "bar"] }
+    let(:config_security_groups)        { [{:foo => "bar"}, {:bar => "foo"}] }
 
     def set_test_values(instance)
       instance.host                   = config_host
@@ -108,6 +110,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_private_port        = config_pf_private_port
       instance.security_group_ids     = config_security_group_ids
       instance.security_group_names   = config_security_group_names
+      instance.security_groups        = config_security_groups
     end
 
     it "should raise an exception if not finalized" do
@@ -146,6 +149,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
       its("security_group_names")   { should == config_security_group_names }
+      its("security_groups")        { should == config_security_groups }
     end
 
     context "with a specific config set" do
@@ -183,6 +187,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_private_port")        { should == config_pf_private_port }
       its("security_group_ids")     { should == config_security_group_ids }
       its("security_group_names")   { should == config_security_group_names }
+      its("security_groups")        { should == config_security_groups }
     end
 
     describe "inheritance of parent config" do


### PR DESCRIPTION
It's easier if the Security Group can be defined in the Vagrantfile.
For example like this:

``` ruby
[...]
config.vm.provider :cloudstack do |cloudstack, override|
    cloudstack.host = "api.exoscale.ch"
    cloudstack.path = "/compute"
    cloudstack.port = "443"
    cloudstack.scheme = "https"
    cloudstack.keypair = "exoscale"

    cloudstack.api_key = "your_api_key"
    cloudstack.secret_key = "your_secret_key"


    cloudstack.template_id = "a17b40d6-83e4-4f2a-9ef0-dce6af575789" #Ubuntu 12.04
    cloudstack.service_offering_id = "71004023-bb72-4a97-b1e9-bc66dfce9470" # Micro instance with 10GB disk
    cloudstack.zone_id = "1128bd56-b4d9-4ac6-a7b9-c715b187ce11" #GV2
    cloudstack.network_type = "Basic"
    cloudstack.security_groups = [
      { 
        :name         => "common", 
        :description  => "created in the Vagrantfile", 
        :rules        => [
          {:type => "ingress", :protocol => "TCP", :startport => 22, :endport => 22, :cidrlist => "0.0.0.0/0"}, 
          {:type => "egress",  :protocol => "TCP", :startport => 23, :endport => 23, :cidrlist => "0.0.0.0/0"}
        ]
      }, 
      { :name         => "test",
        :description  => "Also created in Vagrantfile",
        :rules        => [
          {:type => "ingress", :protocol => "TCP", :startport => 80, :endport => 80, :cidrlist => "0.0.0.0/0"}, 
          {:type => "ingress", :protocol => "TCP", :startport => 443, :endport => 443, :cidrlist => "0.0.0.0/0"}, 
          {:type => "egress", :protocol => "TCP", :startport => 8080, :endport => 8080, :cidrlist => "0.0.0.0/0"}
        ]
      }
    ]
  end

[...]
```

Tested with cloud provider exoscale.ch but I haven't been able to test if there's any impact when using Advanced Networking.

Merry Xmas ! 
