### PR TITLE
Update README.md to reflect Vagrant version needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a fork of [mitchellh AWS Provider](https://github.com/mitchellh/vagrant-
 This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds an [Cloudstack](http://cloudstack.apache.org)
 provider to Vagrant.
 
-**NOTE:** This plugin requires Vagrant 1.2+,
+**NOTE:** This plugin requires Vagrant 1.5+, since v0.4.0.
 
 ## Features
 


### PR DESCRIPTION
Since v0.4.0 release this plugin will only work with Vagrant 1.5 or
higher. Update the documentation to reflect this.
