### PR TITLE
Allow getting credentials from environment variables

### DIFF
--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -237,11 +237,10 @@ module VagrantPlugins
         # Scheme is 'http' by default
         @scheme = "http" if @scheme == UNSET_VALUE
 
-        # Api key must be nil, since we can't default that
-        @api_key = nil if @api_key == UNSET_VALUE
-
-        # Secret key must be nil, since we can't default that
-        @secret_key = nil if @secret_key == UNSET_VALUE
+        # Try to get access keys from environment variables, they will
+        # default to nil if the environment variables are not present
+        @api_key = ENV['CLOUDSTACK_API_KEY'] if @api_key == UNSET_VALUE
+        @secret_key = ENV['CLOUDSTACK_SECRET_KEY'] if @secret_key == UNSET_VALUE
 
         # Set the default timeout for waiting for an instance to be ready
         @instance_ready_timeout = 120 if @instance_ready_timeout == UNSET_VALUE

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -43,6 +43,35 @@ describe VagrantPlugins::Cloudstack::Config do
     its("user_data")              { should be_nil }
   end
 
+  describe "getting credentials from environment" do
+    context "without CloudStack credential environment variables" do
+      subject do
+        instance.tap do |o|
+          o.finalize!
+        end
+      end
+
+      its("api_key")    { should be_nil }
+      its("secret_key") { should be_nil }
+    end
+
+    context "with CloudStack credential variables" do
+      before :each do
+        ENV.stub(:[]).with("CLOUDSTACK_API_KEY").and_return("api_key")
+        ENV.stub(:[]).with("CLOUDSTACK_SECRET_KEY").and_return("secret_key")
+      end
+
+      subject do
+        instance.tap do |o|
+          o.finalize!
+        end
+      end
+
+      its("api_key")    { should == "api_key" }
+      its("secret_key") { should == "secret_key" }
+    end
+  end
+
   describe "overriding defaults" do
     # I typically don't meta-program in tests, but this is a very
     # simple boilerplate test, so I cut corners here. It just sets


### PR DESCRIPTION
The API and secret keys can now be passed through environment
variables CLOUDSTACK_API_KEY and CLOUDSTACK_SECRET_KEY. This
omits the need to store these keys in the Vagrantfile reducing
the risk of accidentally disclosing them.
