### PR TITLE
Change default scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0 (Jun 17, 2014)
+* Change the resolution order of how we discover the scheme to talk to the cloud.
+  This is a possibly breaking change.
+
 # 0.6.0 (May 13, 2014)
 
 * Bump the Ruby version to 2.0.0-p481

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=0.6.0
+VERSION=0.7.0
 mkdir -p /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION
 cp -r . /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION/
 tar -C /tmp/vagrant-cloudstack-build_rpm.$$/ -czf ~/rpmbuild/SOURCES/vagrant-cloudstack-$VERSION.tar.gz vagrant-cloudstack-$VERSION

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -234,8 +234,9 @@ module VagrantPlugins
         # Port must be nil, since we can't default that
         @port = nil if @port == UNSET_VALUE
 
-        # Scheme is 'http' by default
-        @scheme = "http" if @scheme == UNSET_VALUE
+        # We default the scheme to whatever the user has specifid in the .fog file
+        # *OR* whatever is default for the provider in the fog library
+        @scheme = nil if @scheme == UNSET_VALUE
 
         # Try to get access keys from environment variables, they will
         # default to nil if the environment variables are not present

--- a/lib/vagrant-cloudstack/version.rb
+++ b/lib/vagrant-cloudstack/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Cloudstack
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -21,7 +21,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("host")                   { should be_nil }
     its("path")                   { should be_nil }
     its("port")                   { should be_nil }
-    its("scheme")                 { should == "http" }
+    its("scheme")                 { should be_nil }
     its("api_key")                { should be_nil }
     its("secret_key")             { should be_nil }
     its("instance_ready_timeout") { should == 120 }


### PR DESCRIPTION
This is a possibly breaking change as it changes the resolution order
of how we decide what scheme to use when we connect to the provider.

Earlier we picked http if no scheme was provided in the Vagrantfile,
thus overriding any setting in the .fog file or the defaults in the provider.

With this change, we can specify a scheme in the Vagrantfile, the .fog file or
use the providers default as a fallback.
