### PR TITLE
Use URL safe Base64 encoding for user data

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -209,7 +209,7 @@ module VagrantPlugins
             options['name']       = hostname if hostname != nil
 
             if user_data != nil
-              options['user_data'] = Base64.encode64(user_data)
+              options['user_data'] = Base64.urlsafe_encode64(user_data)
               if options['user_data'].length > 2048
                 raise Errors::UserdataError,
                       :userdataLength => options['user_data'].length


### PR DESCRIPTION
Older version of CloudStack may complain about non-printable ASCII
characters in user data unless URL safe Base64 encoding is used.
