### PR TITLE
network_ids is empty if network_id and network_name are not specified

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -130,7 +130,7 @@ module VagrantPlugins
             }
 
             if network_type == "Advanced"
-              options['network_ids'] = [network_id]
+              options['network_ids'] = [network_id] if !network_id.nil?
             elsif network_type == "Basic"
               options['security_group_ids'] = security_group_ids
             end


### PR DESCRIPTION
Now network_ids is empty if network_id and network_name are not specified. This cause following error when 'vagrant up --provider=cloudstack' is executed.

.vagrant.d/gems/gems/fog-core-1.24.0/lib/fog/core/attributes.rb:147:in `requires': identity is required for this operation (ArgumentError)

When network_id and network_name are not specified in Vagrantfile, network_ids should be ommited.
