### PR TITLE
add plugins group to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,9 @@ group :development do
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
 end
 
+group :plugins do
+  gem "vagrant-cloudstack", path: "."
+end
+
 gem 'coveralls', require: false
 


### PR DESCRIPTION
Add plugins group to Gemfile to load this plugin in development.

This commit is the same with the commit of vagrant-aws.
https://github.com/mitchellh/vagrant-aws/commit/6bc5f60051b396d1ae7c2ef490d86bd2eb590117
