### PR TITLE
Allow setting private key and user name for ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_private_port` - Private port for port forwarding rule
 * `display_name` - Display name for the instance
 * `group` - Group for the instance
+* `ssh_key` - Path to a private key to be used with ssh
+* `ssh_user` - User name to be used with ssh
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-cloudstack/action/read_ssh_info.rb
+++ b/lib/vagrant-cloudstack/action/read_ssh_info.rb
@@ -52,11 +52,18 @@ module VagrantPlugins
             end
           end
 
-          unless pf_ip_address.nil?
-            return {:host => pf_ip_address, :port => pf_public_port}
-          else
-            return {:host => server.nics[0]['ipaddress'], :port => 22}
-          end
+          ssh_info = {
+                       :host => pf_ip_address || server.nics[0]['ipaddress'],
+                       :port => pf_public_port
+                     }
+
+          ssh_info = ssh_info.merge({
+            :private_key_path => domain_config.ssh_key,
+            :password         => nil
+          }) unless domain_config.ssh_key.nil?
+          ssh_info = ssh_info.merge({ :username => domain_config.ssh_user }) unless domain_config.ssh_user.nil?
+
+          return ssh_info
         end
       end
     end

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -45,6 +45,8 @@ module VagrantPlugins
           security_group_names  = domain_config.security_group_names
           security_groups       = domain_config.security_groups
           user_data             = domain_config.user_data
+          ssh_key               = domain_config.ssh_key
+          ssh_user              = domain_config.ssh_user
 
           # If for some reason the user have specified both network_name and network_id, take the id since that is
           # more specific than the name. But always try to fetch the name of the network to present to the user.

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -155,6 +155,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :user_data
 
+      # The key to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_key
+
+      # The username to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_user
+
 
       def initialize(domain_specific=false)
         @host                      = UNSET_VALUE
@@ -186,7 +196,8 @@ module VagrantPlugins
         @security_group_names      = UNSET_VALUE
         @security_groups           = UNSET_VALUE
         @user_data                 = UNSET_VALUE
-
+        @ssh_key                   = UNSET_VALUE
+        @ssh_user                  = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -343,6 +354,12 @@ module VagrantPlugins
 
         # User Data is nil by default
         @user_data              = nil if @user_data == UNSET_VALUE
+
+        # ssh key is nil by default
+        @ssh_key                = nil if @ssh_key == UNSET_VALUE
+
+        # ssh key is nil by default
+        @ssh_user               = nil if @ssh_user == UNSET_VALUE
 
         # Compile our domain specific configurations only within
         # NON-DOMAIN-SPECIFIC configurations.


### PR DESCRIPTION
In order to use the plugin with VM templates that are already created and do not include the vagrant user, I need to specify a private key and a user name that matches what is configured in the VM template.

Therefore, I've added two configuration parameters:
- ssh_key
- ssh_user

And propagated those parameters to the ssh configuration.
