### PR TITLE
Enable code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
   gem 'coveralls', require: false
+  gem 'simplecov', require: false
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,9 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
+  gem 'coveralls', require: false
 end
 
 group :plugins do
   gem "vagrant-cloudstack", path: "."
 end
-
-gem 'coveralls', require: false
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'coveralls'
+
+Coveralls.wear!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
 require 'coveralls'
 
+SimpleCov.start
 Coveralls.wear!

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -1,7 +1,5 @@
+require "spec_helper"
 require "vagrant-cloudstack/config"
-
-require 'coveralls'
-Coveralls.wear!
 
 describe VagrantPlugins::Cloudstack::Config do
   let(:instance) { described_class.new }


### PR DESCRIPTION
The first commit (3c0404a) refactors the coverage init code to a spec_helper.rb file that can be reused in other tests.

The second (de695b3) adds `simplecov` gem to the project.

These two changes enabled the coverage analysis by coveralls in my forked repo. Hopefully they will do the same for the main repo.
