### PR TITLE
Toggle port forwarding automatic open firewall rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_ip_address` - IP address for port forwarding rule
 * `pf_public_port` - Public port for port forwarding rule
 * `pf_private_port` - Private port for port forwarding rule
+* `pf_open_firewall` - Flag to enable/disable automatic open firewall rule
 * `port_forwarding_rules` - Port forwarding rules for the virtual machine
 * `firewall_rules` - Firewall rules
 * `display_name` - Display name for the instance

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -41,6 +41,7 @@ module VagrantPlugins
           pf_ip_address         = domain_config.pf_ip_address
           pf_public_port        = domain_config.pf_public_port
           pf_private_port       = domain_config.pf_private_port
+          pf_open_firewall      = domain_config.pf_open_firewall
           port_forwarding_rules = domain_config.port_forwarding_rules
           firewall_rules        = domain_config.firewall_rules
           display_name          = domain_config.display_name
@@ -208,7 +209,7 @@ module VagrantPlugins
               :protocol     => "tcp",
               :publicport   => pf_public_port,
               :privateport  => pf_private_port,
-              :openfirewall => true
+              :openfirewall => pf_open_firewall
             }
             create_port_forwarding_rule(env, port_forwarding_rule)
           end

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -131,6 +131,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :pf_private_port
 
+      # flag to enable/disable automatic open firewall rule
+      #
+      # @return [Boolean]
+      attr_accessor :pf_open_firewall
+
       # comma separated list of port forwarding rules
       # (hash with rule parameters)
       #
@@ -214,6 +219,7 @@ module VagrantPlugins
         @pf_ip_address             = UNSET_VALUE
         @pf_public_port            = UNSET_VALUE
         @pf_private_port           = UNSET_VALUE
+        @pf_open_firewall          = UNSET_VALUE
         @port_forwarding_rules     = UNSET_VALUE
         @firewall_rules            = UNSET_VALUE
         @security_group_ids        = UNSET_VALUE
@@ -354,7 +360,7 @@ module VagrantPlugins
         # Keypair defaults to nil
         @keypair                = nil if @keypair == UNSET_VALUE
 
-        # Static NAT must be empty array 
+        # Static NAT must be empty array
         @static_nat             = [] if @static_nat == UNSET_VALUE
 
         # IP address id must be nil, since we can't default that
@@ -369,10 +375,13 @@ module VagrantPlugins
         # Private port must be nil, since we can't default that
         @pf_private_port        = nil if @pf_private_port == UNSET_VALUE
 
-        # Port forwarding rules  must be empty array 
+        # Open firewall is true by default (for backwards compatibility)
+        @pf_open_firewall       = true if @pf_open_firewall == UNSET_VALUE
+
+        # Port forwarding rules  must be empty array
         @port_forwarding_rules  = [] if @port_forwarding_rules == UNSET_VALUE
 
-        # Firewall rules  must be empty array 
+        # Firewall rules  must be empty array
         @firewall_rules         = [] if @firewall_rules == UNSET_VALUE
 
         # Security Group IDs must be nil, since we can't default that

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -16,35 +16,36 @@ describe VagrantPlugins::Cloudstack::Config do
       end
     end
 
-    its("host")                   { should be_nil }
-    its("path")                   { should be_nil }
-    its("port")                   { should be_nil }
-    its("scheme")                 { should be_nil }
-    its("api_key")                { should be_nil }
-    its("secret_key")             { should be_nil }
-    its("instance_ready_timeout") { should == 120 }
-    its("domain_id")              { should be_nil }
-    its("network_id")             { should be_nil }
-    its("project_id")             { should be_nil }
-    its("service_offering_id")    { should be_nil }
-    its("template_id")            { should be_nil }
-    its("zone_id")                { should be_nil }
-    its("keypair")                { should be_nil }
-    its("static_nat")             { should == []  }
-    its("pf_ip_address_id")       { should be_nil }
-    its("pf_ip_address")          { should be_nil }
-    its("pf_public_port")         { should be_nil }
-    its("pf_private_port")        { should be_nil }
-    its("port_forwarding_rules")  { should == []  }
-    its("firewall_rules")         { should == []  }
-    its("security_group_ids")     { should == []  }
-    its("display_name")           { should be_nil }
-    its("group")                  { should be_nil }
-    its("security_group_names")   { should == []  }
-    its("security_groups")        { should == []  }
-    its("user_data")              { should be_nil }
-    its("ssh_key")                { should be_nil }
-    its("ssh_user")               { should be_nil }
+    its("host")                   { should be_nil  }
+    its("path")                   { should be_nil  }
+    its("port")                   { should be_nil  }
+    its("scheme")                 { should be_nil  }
+    its("api_key")                { should be_nil  }
+    its("secret_key")             { should be_nil  }
+    its("instance_ready_timeout") { should == 120  }
+    its("domain_id")              { should be_nil  }
+    its("network_id")             { should be_nil  }
+    its("project_id")             { should be_nil  }
+    its("service_offering_id")    { should be_nil  }
+    its("template_id")            { should be_nil  }
+    its("zone_id")                { should be_nil  }
+    its("keypair")                { should be_nil  }
+    its("static_nat")             { should == []   }
+    its("pf_ip_address_id")       { should be_nil  }
+    its("pf_ip_address")          { should be_nil  }
+    its("pf_public_port")         { should be_nil  }
+    its("pf_private_port")        { should be_nil  }
+    its("pf_open_firewall")       { should == true }
+    its("port_forwarding_rules")  { should == []   }
+    its("firewall_rules")         { should == []   }
+    its("security_group_ids")     { should == []   }
+    its("display_name")           { should be_nil  }
+    its("group")                  { should be_nil  }
+    its("security_group_names")   { should == []   }
+    its("security_groups")        { should == []   }
+    its("user_data")              { should be_nil  }
+    its("ssh_key")                { should be_nil  }
+    its("ssh_user")               { should be_nil  }
   end
 
   describe "getting credentials from environment" do
@@ -90,6 +91,14 @@ describe VagrantPlugins::Cloudstack::Config do
         instance.finalize!
         instance.send(attribute).should == "foo"
       end
+
+    end
+
+    it 'should not default pf_open_firewall if overridden' do
+      instance.pf_open_firewall = false
+      instance.finalize!
+
+      instance.pf_open_firewall.should == false
     end
   end
 
@@ -127,6 +136,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_ip_address)          { "foo" }
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
+    let(:config_pf_open_firewall)       { false }
     let(:config_port_forwarding_rules)  { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_firewall_rules)         { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_security_group_ids)     { ["foo", "bar"] }
@@ -157,6 +167,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_ip_address          = config_pf_ip_address
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
+      instance.pf_open_firewall       = config_pf_open_firewall
       instance.port_forwarding_rules  = config_port_forwarding_rules
       instance.firewall_rules         = config_firewall_rules
       instance.security_group_ids     = config_security_group_ids
@@ -204,6 +215,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_ip_address")          { should == config_pf_ip_address }
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
+      its("pf_open_firewall")       { should == config_pf_open_firewall }
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
       its("security_group_ids")     { should == config_security_group_ids }
@@ -250,6 +262,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_ip_address")          { should == config_pf_ip_address }
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
+      its("pf_open_firewall")       { should == config_pf_open_firewall }
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
       its("security_group_ids")     { should == config_security_group_ids }


### PR DESCRIPTION
This PR adds a new configuration attribute called `pf_open_firewall`, which is set to `true` by default for backwards compatibility.

When set to `false`, the API call that creates the port forwarding rule does not automatically create a rule to open the firewall.

Fixes #69 
