### PR TITLE
Make network_type optional

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -136,11 +136,8 @@ module VagrantPlugins
                 :image_id     => template_id
             }
 
-            if network_type == "Advanced"
-              options['network_ids'] = [network_id] if !network_id.nil?
-            elsif network_type == "Basic"
-              options['security_group_ids'] = security_group_ids
-            end
+            options['network_ids'] = [network_id] if !network_id.nil?
+            options['security_group_ids'] = security_group_ids if !security_group_ids.nil?
             options['project_id'] = project_id if project_id != nil
             options['key_name']   = keypair if keypair != nil
             options['name']       = hostname if hostname != nil


### PR DESCRIPTION
This patch allows to omit  network_type when Basic network is used. 

network_type is only used to determine which option is used network_ids or security_group_ids.
It can be determine whether variables are nil or not.
