### PR TITLE
Refactor run instance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
@@ -6,11 +6,11 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git'
   gem 'coveralls', require: false
   gem 'simplecov', require: false
 end
 
 group :plugins do
-  gem "vagrant-cloudstack", path: "."
+  gem 'vagrant-cloudstack', path: '.'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ group :development do
   gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git'
   gem 'coveralls', require: false
   gem 'simplecov', require: false
+  gem 'rspec-core'
+  gem 'rspec-expectations'
+  gem 'rspec-its'
+  gem 'rspec-mocks'
 end
 
 group :plugins do

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -28,11 +28,10 @@ module VagrantPlugins
           # Get the configs
           domain_config = env[:machine].provider_config.get_domain_config(domain)
 
-          @zone = CloudstackResource.new(domain_config.zone_id, domain_config.zone_name, 'zone')
+          @zone    = CloudstackResource.new(domain_config.zone_id, domain_config.zone_name, 'zone')
+          @network = CloudstackResource.new(domain_config.network_id, domain_config.network_name, 'network')
 
           hostname              = domain_config.name
-          network_id            = domain_config.network_id
-          network_name          = domain_config.network_name
           network_type          = domain_config.network_type
           project_id            = domain_config.project_id
           service_offering_id   = domain_config.service_offering_id
@@ -62,14 +61,7 @@ module VagrantPlugins
           vm_password           = domain_config.vm_password
           private_ip_address    = domain_config.private_ip_address
 
-          # If for some reason the user have specified both network_name and network_id, take the id since that is
-          # more specific than the name. But always try to fetch the name of the network to present to the user.
-          if network_id.nil? and network_name
-            network_id = name_to_id(env, network_name, 'network')
-          elsif network_id
-            network_name = id_to_name(env, network_id, 'network')
-          end
-
+          @resource_service.sync_resource(@network)
           @resource_service.sync_resource(@zone, { 'available' => true })
 
           if service_offering_id.nil? and service_offering_name
@@ -132,7 +124,7 @@ module VagrantPlugins
           env[:ui].info(" -- Template: #{template_name} (#{template_id})")
           env[:ui].info(" -- Project UUID: #{project_id}") unless project_id.nil?
           env[:ui].info(" -- Zone: #{@zone.name} (#{@zone.id})")
-          env[:ui].info(" -- Network: #{network_name} (#{network_id})") unless network_id.nil?
+          env[:ui].info(" -- Network: #{@network.name} (#{@network.id})") unless @network.id.nil?
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(' -- User Data: Yes') if user_data
           security_group_names.zip(security_group_ids).each do |security_group_name, security_group_id|
@@ -148,7 +140,7 @@ module VagrantPlugins
                 :image_id     => template_id
             }
 
-            options['network_ids'] = network_id unless network_id.nil?
+            options['network_ids'] = @network.id unless @network.id.nil?
             options['security_group_ids'] = security_group_ids unless security_group_ids.nil?
             options['project_id'] = project_id unless project_id.nil?
             options['key_name']   = keypair unless keypair.nil?
@@ -171,7 +163,7 @@ module VagrantPlugins
             # XXX FIXME vpc?
             if e.message =~ /subnet ID/
               raise Errors::FogError,
-                    :message => "Subnet ID not found: #{network_id}"
+                    :message => "Subnet ID not found: #{@network.id}"
             end
 
             raise

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -1,6 +1,6 @@
-require "log4r"
-require "vagrant/util/retryable"
-require "vagrant-cloudstack/util/timer"
+require 'log4r'
+require 'vagrant/util/retryable'
+require 'vagrant-cloudstack/util/timer'
 
 module VagrantPlugins
   module Cloudstack
@@ -11,7 +11,7 @@ module VagrantPlugins
 
         def initialize(app, env)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_cloudstack::action::run_instance")
+          @logger = Log4r::Logger.new('vagrant_cloudstack::action::run_instance')
         end
 
         def call(env)
@@ -60,43 +60,43 @@ module VagrantPlugins
           # If for some reason the user have specified both network_name and network_id, take the id since that is
           # more specific than the name. But always try to fetch the name of the network to present to the user.
           if network_id.nil? and network_name
-            network_id = name_to_id(env, network_name, "network")
+            network_id = name_to_id(env, network_name, 'network')
           elsif network_id
-            network_name = id_to_name(env, network_id, "network")
+            network_name = id_to_name(env, network_id, 'network')
           end
 
           if zone_id.nil? and zone_name
-            zone_id = name_to_id(env, zone_name, "zone", {'available' => true})
+            zone_id = name_to_id(env, zone_name, 'zone', {'available' => true})
           elsif zone_id
-            zone_name = id_to_name(env, zone_id, "zone", {'available' => true})
+            zone_name = id_to_name(env, zone_id, 'zone', {'available' => true})
           end
 
           if service_offering_id.nil? and service_offering_name
-            service_offering_id = name_to_id(env, service_offering_name, "service_offering")
+            service_offering_id = name_to_id(env, service_offering_name, 'service_offering')
           elsif service_offering_id
-            service_offering_name = id_to_name(env, service_offering_id, "service_offering")
+            service_offering_name = id_to_name(env, service_offering_id, 'service_offering')
           end
 
           if disk_offering_id.nil? and disk_offering_name
-            disk_offering_id = name_to_id(env, disk_offering_name, "disk_offering")
+            disk_offering_id = name_to_id(env, disk_offering_name, 'disk_offering')
           elsif disk_offering_id
-            disk_offering_name = id_to_name(env, disk_offering_id, "disk_offering")
+            disk_offering_name = id_to_name(env, disk_offering_id, 'disk_offering')
           end
 
           if template_id.nil? and template_name
-            template_id = name_to_id(env, template_name, "template", {'zoneid'         => zone_id,
+            template_id = name_to_id(env, template_name, 'template', {'zoneid'         => zone_id,
                                                                       'templatefilter' => 'executable'})
           elsif template_id
-            template_name = id_to_name(env, template_id, "template", {'zoneid'         => zone_id,
+            template_name = id_to_name(env, template_id, 'template', {'zoneid'         => zone_id,
                                                                       'templatefilter' => 'executable'})
           end
 
           # Can't use Security Group IDs and Names at the same time
           # Let's use IDs by default...
           if security_group_ids.empty? and !security_group_names.empty?
-            security_group_ids = security_group_names.map { |name| name_to_id(env, name, "security_group") }
+            security_group_ids = security_group_names.map { |name| name_to_id(env, name, 'security_group') }
           elsif !security_group_ids.empty?
-            security_group_names = security_group_ids.map { |id| id_to_name(env, id, "security_group") }
+            security_group_names = security_group_ids.map { |id| id_to_name(env, id, 'security_group') }
           end
 
           # Still no security group ids huh?
@@ -111,19 +111,19 @@ module VagrantPlugins
 
           # If there is no keypair then warn the user
           if !keypair
-            env[:ui].warn(I18n.t("vagrant_cloudstack.launch_no_keypair"))
+            env[:ui].warn(I18n.t('vagrant_cloudstack.launch_no_keypair'))
           end
 
           if display_name.nil?
             local_user = ENV['USER'].dup
-            local_user.gsub!(/[^-a-z0-9_]/i, "")
+            local_user.gsub!(/[^-a-z0-9_]/i, '')
             prefix = env[:root_path].basename.to_s
-            prefix.gsub!(/[^-a-z0-9_]/i, "")
-            display_name = local_user + "_" + prefix + "_#{Time.now.to_i}"
+            prefix.gsub!(/[^-a-z0-9_]/i, '')
+            display_name = local_user + '_' + prefix + "_#{Time.now.to_i}"
           end
 
           # Launch!
-          env[:ui].info(I18n.t("vagrant_cloudstack.launching_instance"))
+          env[:ui].info(I18n.t('vagrant_cloudstack.launching_instance'))
           env[:ui].info(" -- Display Name: #{display_name}")
           env[:ui].info(" -- Group: #{group}") if group
           env[:ui].info(" -- Service offering: #{service_offering_name} (#{service_offering_id})")
@@ -133,7 +133,7 @@ module VagrantPlugins
           env[:ui].info(" -- Zone: #{zone_name} (#{zone_id})")
           env[:ui].info(" -- Network: #{network_name} (#{network_id})") unless network_id.nil?
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
-          env[:ui].info(" -- User Data: Yes") if user_data
+          env[:ui].info(' -- User Data: Yes') if user_data
           security_group_names.zip(security_group_ids).each do |security_group_name, security_group_id|
               env[:ui].info(" -- Security Group: #{security_group_name} (#{security_group_id})")
           end
@@ -182,10 +182,10 @@ module VagrantPlugins
           env[:machine].id                     = server.id
 
           # Wait for the instance to be ready first
-          env[:metrics]["instance_ready_time"] = Util::Timer.time do
+          env[:metrics]['instance_ready_time'] = Util::Timer.time do
             tries = domain_config.instance_ready_timeout / 2
 
-            env[:ui].info(I18n.t("vagrant_cloudstack.waiting_for_ready"))
+            env[:ui].info(I18n.t('vagrant_cloudstack.waiting_for_ready'))
             begin
               retryable(:on => Fog::Errors::TimeoutError, :tries => tries) do
                 # If we're interrupted don't worry about waiting
@@ -204,7 +204,7 @@ module VagrantPlugins
             end
           end
 
-          @logger.info("Time to instance ready: #{env[:metrics]["instance_ready_time"]}")
+          @logger.info("Time to instance ready: #{env[:metrics]['instance_ready_time']}")
 
           if server.password_enabled and server.respond_to?("job_id")
             server_job_result = env[:cloudstack_compute].jobs.get(server.job_id).job_result
@@ -230,7 +230,7 @@ module VagrantPlugins
             port_forwarding_rule = {
               :ipaddressid  => pf_ip_address_id,
               :ipaddress    => pf_ip_address,
-              :protocol     => "tcp",
+              :protocol     => 'tcp',
               :publicport   => pf_public_port,
               :privateport  => pf_private_port,
               :openfirewall => pf_open_firewall
@@ -251,11 +251,11 @@ module VagrantPlugins
           end
 
           if !env[:interrupted]
-            env[:metrics]["instance_ssh_time"] = Util::Timer.time do
+            env[:metrics]['instance_ssh_time'] = Util::Timer.time do
               # Wait for communicator to be ready.
               communicator = env[:machine].config.vm.communicator
-              communicator = "SSH" if communicator.nil?
-              env[:ui].info(I18n.t("vagrant_cloudstack.waiting_for_communicator", :communicator => communicator.to_s.upcase))
+              communicator = 'SSH' if communicator.nil?
+              env[:ui].info(I18n.t('vagrant_cloudstack.waiting_for_communicator', :communicator => communicator.to_s.upcase))
               while true
                 # If we're interrupted then just back out
                 break if env[:interrupted]
@@ -264,10 +264,10 @@ module VagrantPlugins
               end
             end
 
-            @logger.info("Time for SSH ready: #{env[:metrics]["instance_ssh_time"]}")
+            @logger.info("Time for SSH ready: #{env[:metrics]['instance_ssh_time']}")
 
             # Ready and booted!
-            env[:ui].info(I18n.t("vagrant_cloudstack.ready"))
+            env[:ui].info(I18n.t('vagrant_cloudstack.ready'))
           end
 
           # Terminate the instance if we were interrupted
@@ -279,11 +279,11 @@ module VagrantPlugins
         def create_security_group(env, security_group)
           begin
             sgid = env[:cloudstack_compute].create_security_group(:name        => security_group[:name],
-                                                                  :description => security_group[:description])["createsecuritygroupresponse"]["securitygroup"]["id"]
+                                                                  :description => security_group[:description])['createsecuritygroupresponse']['securitygroup']['id']
             env[:ui].info(" -- Security Group #{security_group[:name]} created with ID: #{sgid}")
           rescue Exception => e
             if e.message =~ /already exis/
-              sgid = name_to_id(env, security_group[:name], "security_group")
+              sgid = name_to_id(env, security_group[:name], 'security_group')
               env[:ui].info(" -- Security Group #{security_group[:name]} found with ID: #{sgid}")
             end
           end
@@ -314,7 +314,7 @@ module VagrantPlugins
         end
 
         def recover(env)
-          return if env["vagrant.error"].is_a?(Vagrant::Errors::VagrantError)
+          return if env['vagrant.error'].is_a?(Vagrant::Errors::VagrantError)
 
           if env[:machine].provider.state.id != :not_created
             # Undo the import
@@ -323,14 +323,14 @@ module VagrantPlugins
         end
 
         def enable_static_nat(env, rule)
-          env[:ui].info(I18n.t("vagrant_cloudstack.enabling_static_nat"))
+          env[:ui].info(I18n.t('vagrant_cloudstack.enabling_static_nat'))
 
           ip_address_id = rule[:ipaddressid]
           ip_address    = rule[:ipaddress]
 
           if ip_address_id.nil? and ip_address.nil?
-            @logger.info("IP address is not specified. Skip enabling static nat.")
-            env[:ui].info(I18n.t("IP address is not specified. Skip enabling static nat."))
+            @logger.info('IP address is not specified. Skip enabling static nat.')
+            env[:ui].info(I18n.t('IP address is not specified. Skip enabling static nat.'))
             return
           end
 
@@ -343,17 +343,17 @@ module VagrantPlugins
           env[:ui].info(" -- IP address : #{ip_address} (#{ip_address_id})")
 
           options = {
-              :command          => "enableStaticNat",
+              :command          => 'enableStaticNat',
               :ipaddressid      => ip_address_id,
               :virtualmachineid => env[:machine].id
           }
 
           begin
             resp = env[:cloudstack_compute].request(options)
-            is_success = resp["enablestaticnatresponse"]["success"]
+            is_success = resp['enablestaticnatresponse']['success']
 
-            if is_success != "true"
-              env[:ui].warn(" -- Failed to enable static nat: #{resp["enablestaticnatresponse"]["errortext"]}")
+            if is_success != 'true'
+              env[:ui].warn(" -- Failed to enable static nat: #{resp['enablestaticnatresponse']['errortext']}")
               return
             end
           rescue Fog::Compute::Cloudstack::Error => e
@@ -368,14 +368,14 @@ module VagrantPlugins
         end
 
         def create_port_forwarding_rule(env, rule)
-          env[:ui].info(I18n.t("vagrant_cloudstack.creating_port_forwarding_rule"))
+          env[:ui].info(I18n.t('vagrant_cloudstack.creating_port_forwarding_rule'))
 
           ip_address_id = rule[:ipaddressid]
           ip_address    = rule[:ipaddress]
 
           if ip_address_id.nil? and ip_address.nil?
-            @logger.info("IP address is not specified. Skip creating port forwarding rule.")
-            env[:ui].info(I18n.t("IP address is not specified. Skip creating port forwarding rule."))
+            @logger.info('IP address is not specified. Skip creating port forwarding rule.')
+            env[:ui].info(I18n.t('IP address is not specified. Skip creating port forwarding rule.'))
             return
           end
 
@@ -402,17 +402,17 @@ module VagrantPlugins
 
           begin
             resp = env[:cloudstack_compute].create_port_forwarding_rule(options)
-            job_id = resp["createportforwardingruleresponse"]["jobid"]
+            job_id = resp['createportforwardingruleresponse']['jobid']
 
             if job_id.nil?
-              env[:ui].warn(" -- Failed to create port forwarding rule: #{resp["createportforwardingruleresponse"]["errortext"]}")
+              env[:ui].warn(" -- Failed to create port forwarding rule: #{resp['createportforwardingruleresponse']['errortext']}")
               return
             end
 
             while true
               response = env[:cloudstack_compute].query_async_job_result({:jobid => job_id})
-              if response["queryasyncjobresultresponse"]["jobstatus"] != 0
-                port_forwarding_rule = response["queryasyncjobresultresponse"]["jobresult"]["portforwardingrule"]
+              if response['queryasyncjobresultresponse']['jobstatus'] != 0
+                port_forwarding_rule = response['queryasyncjobresultresponse']['jobresult']['portforwardingrule']
                 break
               else
                 sleep 2
@@ -425,19 +425,19 @@ module VagrantPlugins
           # Save port forwarding rule id to the data dir so it can be released when the instance is destroyed
           port_forwarding_file = env[:machine].data_dir.join('port_forwarding')
           port_forwarding_file.open('a+') do |f|
-            f.write("#{port_forwarding_rule["id"]}\n")
+            f.write("#{port_forwarding_rule['id']}\n")
           end
         end
 
         def create_firewall_rule(env, rule)
-          env[:ui].info(I18n.t("vagrant_cloudstack.creating_firewall_rule"))
+          env[:ui].info(I18n.t('vagrant_cloudstack.creating_firewall_rule'))
 
           ip_address_id = rule[:ipaddressid]
           ip_address    = rule[:ipaddress]
 
           if ip_address_id.nil? and ip_address.nil?
-            @logger.info("IP address is not specified. Skip creating firewall rule.")
-            env[:ui].info(I18n.t("IP address is not specified. Skip creating firewall rule."))
+            @logger.info('IP address is not specified. Skip creating firewall rule.')
+            env[:ui].info(I18n.t('IP address is not specified. Skip creating firewall rule.'))
             return
           end
 
@@ -456,7 +456,7 @@ module VagrantPlugins
           env[:ui].info(" -- ICMP type  : #{rule[:icmptype]}")
 
           options = {
-              :command          => "createFirewallRule",
+              :command          => 'createFirewallRule',
               :ipaddressid      => ip_address_id,
               :protocol         => rule[:protocol],
               :cidrlist         => rule[:cidrlist],
@@ -468,17 +468,17 @@ module VagrantPlugins
 
           begin
             resp = env[:cloudstack_compute].request(options)
-            job_id = resp["createfirewallruleresponse"]["jobid"]
+            job_id = resp['createfirewallruleresponse']['jobid']
 
             if job_id.nil?
-              env[:ui].warn(" -- Failed to create firewall rule: #{resp["createfirewallruleresponse"]["errortext"]}")
+              env[:ui].warn(" -- Failed to create firewall rule: #{resp['createfirewallruleresponse']['errortext']}")
               return
             end
 
             while true
               response = env[:cloudstack_compute].query_async_job_result({:jobid => job_id})
-              if response["queryasyncjobresultresponse"]["jobstatus"] != 0
-                firewall_rule = response["queryasyncjobresultresponse"]["jobresult"]["firewallrule"]
+              if response['queryasyncjobresultresponse']['jobstatus'] != 0
+                firewall_rule = response['queryasyncjobresultresponse']['jobresult']['firewallrule']
                 break
               else
                 sleep 2
@@ -491,7 +491,7 @@ module VagrantPlugins
           # Save firewall rule id to the data dir so it can be released when the instance is destroyed
           firewall_file = env[:machine].data_dir.join('firewall')
           firewall_file.open('a+') do |f|
-            f.write("#{firewall_rule["id"]}\n")
+            f.write("#{firewall_rule['id']}\n")
           end
         end
 
@@ -506,8 +506,8 @@ module VagrantPlugins
         private
 
         def translate_from_to(env, resource_type, options)
-          if resource_type == "public_ip_address"
-            pluralised_type = "public_ip_addresses"
+          if resource_type == 'public_ip_address'
+            pluralised_type = 'public_ip_addresses'
           else
             pluralised_type = "#{resource_type}s"
           end

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -129,9 +129,9 @@ module VagrantPlugins
           env[:ui].info(" -- Service offering: #{service_offering_name} (#{service_offering_id})")
           env[:ui].info(" -- Disk offering: #{disk_offering_name} (#{disk_offering_id})") unless disk_offering_id.nil?
           env[:ui].info(" -- Template: #{template_name} (#{template_id})")
-          env[:ui].info(" -- Project UUID: #{project_id}") if project_id != nil
+          env[:ui].info(" -- Project UUID: #{project_id}") unless project_id.nil?
           env[:ui].info(" -- Zone: #{zone_name} (#{zone_id})")
-          env[:ui].info(" -- Network: #{network_name} (#{network_id})") if !network_id.nil? or !network_name.nil?
+          env[:ui].info(" -- Network: #{network_name} (#{network_id})") unless network_id.nil?
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(" -- User Data: Yes") if user_data
           security_group_names.zip(security_group_ids).each do |security_group_name, security_group_id|
@@ -147,13 +147,13 @@ module VagrantPlugins
                 :image_id     => template_id
             }
 
-            options['network_ids'] = network_id if !network_id.nil?
-            options['security_group_ids'] = security_group_ids if !security_group_ids.nil?
-            options['project_id'] = project_id if project_id != nil
-            options['key_name']   = keypair if keypair != nil
-            options['name']       = hostname if hostname != nil
-            options['ip_address'] = private_ip_address if private_ip_address != nil
-            options['disk_offering_id'] = disk_offering_id if disk_offering_id != nil
+            options['network_ids'] = network_id unless network_id.nil?
+            options['security_group_ids'] = security_group_ids unless security_group_ids.nil?
+            options['project_id'] = project_id unless project_id.nil?
+            options['key_name']   = keypair unless keypair.nil?
+            options['name']       = hostname unless hostname.nil?
+            options['ip_address'] = private_ip_address unless private_ip_address.nil?
+            options['disk_offering_id'] = disk_offering_id unless disk_offering_id.nil?
 
             if user_data != nil
               options['user_data'] = Base64.urlsafe_encode64(user_data)

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
           env[:ui].info(" -- Display Name: #{display_name}")
           env[:ui].info(" -- Group: #{group}") if group
           env[:ui].info(" -- Service offering: #{service_offering_name} (#{service_offering_id})")
-          env[:ui].info(" -- Disk offering: #{disk_offering_name} (#{disk_offering_id})")
+          env[:ui].info(" -- Disk offering: #{disk_offering_name} (#{disk_offering_id})") unless disk_offering_id.nil?
           env[:ui].info(" -- Template: #{template_name} (#{template_id})")
           env[:ui].info(" -- Project UUID: #{project_id}") if project_id != nil
           env[:ui].info(" -- Zone: #{zone_name} (#{zone_id})")

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -28,14 +28,13 @@ module VagrantPlugins
           # Get the configs
           domain_config = env[:machine].provider_config.get_domain_config(domain)
 
-          @zone    = CloudstackResource.new(domain_config.zone_id, domain_config.zone_name, 'zone')
-          @network = CloudstackResource.new(domain_config.network_id, domain_config.network_name, 'network')
+          @zone             = CloudstackResource.new(domain_config.zone_id, domain_config.zone_name, 'zone')
+          @network          = CloudstackResource.new(domain_config.network_id, domain_config.network_name, 'network')
+          @service_offering = CloudstackResource.new(domain_config.service_offering_id, domain_config.service_offering_name, 'service_offering')
 
           hostname              = domain_config.name
           network_type          = domain_config.network_type
           project_id            = domain_config.project_id
-          service_offering_id   = domain_config.service_offering_id
-          service_offering_name = domain_config.service_offering_name
           disk_offering_id      = domain_config.disk_offering_id
           disk_offering_name    = domain_config.disk_offering_name
           template_id           = domain_config.template_id
@@ -61,14 +60,9 @@ module VagrantPlugins
           vm_password           = domain_config.vm_password
           private_ip_address    = domain_config.private_ip_address
 
-          @resource_service.sync_resource(@network)
           @resource_service.sync_resource(@zone, { 'available' => true })
-
-          if service_offering_id.nil? and service_offering_name
-            service_offering_id = name_to_id(env, service_offering_name, 'service_offering')
-          elsif service_offering_id
-            service_offering_name = id_to_name(env, service_offering_id, 'service_offering')
-          end
+          @resource_service.sync_resource(@network)
+          @resource_service.sync_resource(@service_offering)
 
           if disk_offering_id.nil? and disk_offering_name
             disk_offering_id = name_to_id(env, disk_offering_name, 'disk_offering')
@@ -119,7 +113,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t('vagrant_cloudstack.launching_instance'))
           env[:ui].info(" -- Display Name: #{display_name}")
           env[:ui].info(" -- Group: #{group}") if group
-          env[:ui].info(" -- Service offering: #{service_offering_name} (#{service_offering_id})")
+          env[:ui].info(" -- Service offering: #{@service_offering.name} (#{@service_offering.id})")
           env[:ui].info(" -- Disk offering: #{disk_offering_name} (#{disk_offering_id})") unless disk_offering_id.nil?
           env[:ui].info(" -- Template: #{template_name} (#{template_id})")
           env[:ui].info(" -- Project UUID: #{project_id}") unless project_id.nil?
@@ -136,7 +130,7 @@ module VagrantPlugins
                 :display_name => display_name,
                 :group        => group,
                 :zone_id      => @zone.id,
-                :flavor_id    => service_offering_id,
+                :flavor_id    => @service_offering.id,
                 :image_id     => template_id
             }
 

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -1,6 +1,8 @@
 require 'log4r'
 require 'vagrant/util/retryable'
 require 'vagrant-cloudstack/util/timer'
+require 'vagrant-cloudstack/model/cloudstack_resource'
+require 'vagrant-cloudstack/service/cloudstack_resource_service'
 
 module VagrantPlugins
   module Cloudstack
@@ -8,10 +10,13 @@ module VagrantPlugins
       # This runs the configured instance.
       class RunInstance
         include Vagrant::Util::Retryable
+        include VagrantPlugins::Cloudstack::Model
+        include VagrantPlugins::Cloudstack::Service
 
         def initialize(app, env)
-          @app    = app
-          @logger = Log4r::Logger.new('vagrant_cloudstack::action::run_instance')
+          @app              = app
+          @logger           = Log4r::Logger.new('vagrant_cloudstack::action::run_instance')
+          @resource_service = CloudstackResourceService.new(env[:cloudstack_compute], env[:ui])
         end
 
         def call(env)
@@ -19,13 +24,13 @@ module VagrantPlugins
           env[:metrics]         ||= {}
 
           # Get the domain we're going to booting up in
-          domain                = env[:machine].provider_config.domain_id
-
+          domain        = env[:machine].provider_config.domain_id
           # Get the configs
-          domain_config         = env[:machine].provider_config.get_domain_config(domain)
+          domain_config = env[:machine].provider_config.get_domain_config(domain)
+
+          @zone = CloudstackResource.new(domain_config.zone_id, domain_config.zone_name, 'zone')
+
           hostname              = domain_config.name
-          zone_id               = domain_config.zone_id
-          zone_name             = domain_config.zone_name
           network_id            = domain_config.network_id
           network_name          = domain_config.network_name
           network_type          = domain_config.network_type
@@ -65,11 +70,7 @@ module VagrantPlugins
             network_name = id_to_name(env, network_id, 'network')
           end
 
-          if zone_id.nil? and zone_name
-            zone_id = name_to_id(env, zone_name, 'zone', {'available' => true})
-          elsif zone_id
-            zone_name = id_to_name(env, zone_id, 'zone', {'available' => true})
-          end
+          @resource_service.sync_resource(@zone, { 'available' => true })
 
           if service_offering_id.nil? and service_offering_name
             service_offering_id = name_to_id(env, service_offering_name, 'service_offering')
@@ -84,10 +85,10 @@ module VagrantPlugins
           end
 
           if template_id.nil? and template_name
-            template_id = name_to_id(env, template_name, 'template', {'zoneid'         => zone_id,
+            template_id = name_to_id(env, template_name, 'template', {'zoneid'         => @zone.id,
                                                                       'templatefilter' => 'executable'})
           elsif template_id
-            template_name = id_to_name(env, template_id, 'template', {'zoneid'         => zone_id,
+            template_name = id_to_name(env, template_id, 'template', {'zoneid'         => @zone.id,
                                                                       'templatefilter' => 'executable'})
           end
 
@@ -130,7 +131,7 @@ module VagrantPlugins
           env[:ui].info(" -- Disk offering: #{disk_offering_name} (#{disk_offering_id})") unless disk_offering_id.nil?
           env[:ui].info(" -- Template: #{template_name} (#{template_id})")
           env[:ui].info(" -- Project UUID: #{project_id}") unless project_id.nil?
-          env[:ui].info(" -- Zone: #{zone_name} (#{zone_id})")
+          env[:ui].info(" -- Zone: #{@zone.name} (#{@zone.id})")
           env[:ui].info(" -- Network: #{network_name} (#{network_id})") unless network_id.nil?
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(' -- User Data: Yes') if user_data
@@ -142,7 +143,7 @@ module VagrantPlugins
             options = {
                 :display_name => display_name,
                 :group        => group,
-                :zone_id      => zone_id,
+                :zone_id      => @zone.id,
                 :flavor_id    => service_offering_id,
                 :image_id     => template_id
             }

--- a/lib/vagrant-cloudstack/exceptions/exceptions.rb
+++ b/lib/vagrant-cloudstack/exceptions/exceptions.rb
@@ -1,0 +1,8 @@
+module VagrantPlugins
+  module Cloudstack
+    module Exceptions
+      class IpNotFoundException < Exception
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -1,0 +1,21 @@
+module VagrantPlugins
+  module Cloudstack
+    module Model
+      class CloudstackResource
+        attr_accessor :id, :name
+        attr_reader   :kind
+
+        def initialize(id, name, kind)
+          raise 'Resource must have a kind' if kind.nil? || kind.empty?
+          @id             = id
+          @name           = name
+          @kind           = kind
+        end
+
+        def to_s
+          "#{kind} - #{id || 'unknown id'}:#{name || 'unknown name'}"
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
         end
 
         def to_s
-          "#{kind} - #{id || 'unknown id'}:#{name || 'unknown name'}"
+          "#{kind} - #{id || '<unknown id>'}:#{name || '<unknown name>'}"
         end
       end
     end

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -12,6 +12,18 @@ module VagrantPlugins
           @kind           = kind
         end
 
+        def is_undefined?
+          is_id_undefined? and is_name_undefined?
+        end
+
+        def is_id_undefined?
+          id.nil? || id.empty?
+        end
+
+        def is_name_undefined?
+          name.nil? || name.empty?
+        end
+
         def to_s
           "#{kind} - #{id || '<unknown id>'}:#{name || '<unknown name>'}"
         end

--- a/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
@@ -8,12 +8,12 @@ module VagrantPlugins
         end
 
         def sync_resource(resource, api_parameters = {})
-          @ui.detail("Syncronizing resource: #{resource}")
           if resource.id.nil? and resource.name
             resource.id = name_to_id(resource.name, resource.kind, api_parameters)
           elsif resource.id
             resource.name = id_to_name(resource.id, resource.kind, api_parameters)
           end
+          @ui.detail("Syncronized resource: #{resource}")
         end
 
         private

--- a/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
@@ -1,0 +1,56 @@
+module VagrantPlugins
+  module Cloudstack
+    module Service
+      class CloudstackResourceService
+        def initialize(cloudstack_compute, ui)
+          @cloudstack_compute = cloudstack_compute
+          @ui                 = ui
+        end
+
+        def sync_resource(resource, api_parameters = {})
+          @ui.detail("Syncronizing resource: #{resource}")
+          if resource.id.nil? and resource.name
+            resource.id = name_to_id(resource.name, resource.kind, api_parameters)
+          elsif resource.id
+            resource.name = id_to_name(resource.id, resource.kind, api_parameters)
+          end
+        end
+
+        private
+
+        def translate_from_to(resource_type, options)
+          if resource_type == 'public_ip_address'
+            pluralised_type = 'public_ip_addresses'
+          else
+            pluralised_type = "#{resource_type}s"
+          end
+
+          full_response = @cloudstack_compute.send("list_#{pluralised_type}".to_sym, options)
+          full_response["list#{pluralised_type.tr('_', '')}response"][resource_type.tr('_', '')]
+        end
+
+        def resourcefield_to_id(resource_type, resource_field, resource_field_value, options={})
+          @ui.info("Fetching UUID for #{resource_type} with #{resource_field} '#{resource_field_value}'")
+          full_response = translate_from_to(resource_type, options)
+          result        = full_response.find {|type| type[resource_field] == resource_field_value }
+          result['id']
+        end
+
+        def id_to_resourcefield(resource_id, resource_type, resource_field, options={})
+          @ui.info("Fetching #{resource_field} for #{resource_type} with UUID '#{resource_id}'")
+          options = options.merge({'id' => resource_id})
+          full_response = translate_from_to(resource_type, options)
+          full_response[0][resource_field]
+        end
+
+        def name_to_id(resource_name, resource_type, options={})
+          resourcefield_to_id(resource_type, 'name', resource_name, options)
+        end
+
+        def id_to_name(resource_id, resource_type, options={})
+          id_to_resourcefield(resource_id, resource_type, 'name', options)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
@@ -44,11 +44,13 @@ module VagrantPlugins
         end
 
         def name_to_id(resource_name, resource_type, options={})
-          resourcefield_to_id(resource_type, 'name', resource_name, options)
+          resource_field = resource_type == 'public_ip_address' ? 'ipaddress' : 'name'
+          resourcefield_to_id(resource_type, resource_field, resource_name, options)
         end
 
         def id_to_name(resource_id, resource_type, options={})
-          id_to_resourcefield(resource_id, resource_type, 'name', options)
+          resource_field = resource_type == 'public_ip_address' ? 'ipaddress' : 'name'
+          id_to_resourcefield(resource_id, resource_type, resource_field, options)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 require 'coveralls'
+require 'rspec/its'
 
 SimpleCov.start
 Coveralls.wear!

--- a/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
@@ -12,6 +12,18 @@ describe CloudstackResource do
         expect(resource.to_s).to be_eql 'kind - id:name'
       end
     end
+
+    describe '#is_undefined?' do
+      it { expect(resource.is_undefined?).to be_eql false }
+    end
+
+    describe '#is_id_undefined?' do
+      it { expect(resource.is_id_undefined?).to be_eql false }
+    end
+
+    describe '#is_name_undefined?' do
+      it { expect(resource.is_name_undefined?).to be_eql false }
+    end
   end
 
   context 'when kind is not defined' do
@@ -24,5 +36,38 @@ describe CloudstackResource do
         expect { CloudstackResource.new('id', 'name', '') }.to raise_error('Resource must have a kind')
       end
     end
+  end
+
+  describe '#is_undefined?' do
+    it { expect(CloudstackResource.new('', '', 'kind').is_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, '', 'kind').is_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('', nil, 'kind').is_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, nil, 'kind').is_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('id', nil, 'kind').is_undefined?).to be_eql false }
+    it { expect(CloudstackResource.new(nil, 'name', 'kind').is_undefined?).to be_eql false }
+    it { expect(CloudstackResource.new('id', '', 'kind').is_undefined?).to be_eql false }
+    it { expect(CloudstackResource.new('', 'name', 'kind').is_undefined?).to be_eql false }
+  end
+
+  describe '#is_id_undefined?' do
+    it { expect(CloudstackResource.new('', 'name', 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, 'name', 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('', '', 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, '', 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('', nil, 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, nil, 'kind').is_id_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('id', nil, 'kind').is_id_undefined?).to be_eql false }
+    it { expect(CloudstackResource.new('id', '', 'kind').is_id_undefined?).to be_eql false }
+  end
+
+  describe '#is_name_undefined?' do
+    it { expect(CloudstackResource.new('id', '', 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('id', nil, 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('', '', 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, '', 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new('', nil, 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, nil, 'kind').is_name_undefined?).to be_eql true }
+    it { expect(CloudstackResource.new(nil, 'name', 'kind').is_name_undefined?).to be_eql false }
+    it { expect(CloudstackResource.new('', 'name', 'kind').is_name_undefined?).to be_eql false }
   end
 end

--- a/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'vagrant-cloudstack/model/cloudstack_resource'
+
+include VagrantPlugins::Cloudstack::Model
+
+describe CloudstackResource do
+  context 'when all attribtues are defined' do
+    let(:resource) { CloudstackResource.new('id', 'name', 'kind') }
+
+    describe '#to_s' do
+      it 'prints the resource with all attributes' do
+        expect(resource.to_s).to be_eql 'kind - id:name'
+      end
+    end
+  end
+
+  context 'when kind is not defined' do
+    describe '#new' do
+      it 'raises an error when kind is nil' do
+        expect { CloudstackResource.new('id', 'name', nil) }.to raise_error('Resource must have a kind')
+      end
+
+      it 'raises an error when kind is empty' do
+        expect { CloudstackResource.new('id', 'name', '') }.to raise_error('Resource must have a kind')
+      end
+    end
+  end
+end

--- a/spec/vagrant-cloudstack/service/cloudstack_resource_service_spec.rb
+++ b/spec/vagrant-cloudstack/service/cloudstack_resource_service_spec.rb
@@ -26,12 +26,18 @@ describe CloudstackResourceService do
   describe '#sync_resource' do
     it 'retrives the missing name' do
       resource = CloudstackResource.new('resource id', nil, 'kind')
-      expect(service.sync_resource(resource)).to be_eql 'resource name'
+      service.sync_resource(resource)
+
+      expect(resource.name).to be_eql 'resource name'
+      expect(resource.id).to be_eql 'resource id'
     end
 
     it 'retrives the missing id' do
       resource = CloudstackResource.new(nil, 'resource name', 'kind')
-      expect(service.sync_resource(resource)).to be_eql 'resource id'
+      service.sync_resource(resource)
+
+      expect(resource.id).to be_eql 'resource id'
+      expect(resource.name).to be_eql 'resource name'
     end
   end
 end

--- a/spec/vagrant-cloudstack/service/cloudstack_resource_service_spec.rb
+++ b/spec/vagrant-cloudstack/service/cloudstack_resource_service_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'vagrant-cloudstack/model/cloudstack_resource'
+require 'vagrant-cloudstack/service/cloudstack_resource_service'
+
+include VagrantPlugins::Cloudstack::Model
+include VagrantPlugins::Cloudstack::Service
+
+describe CloudstackResourceService do
+  let(:cloudstack_compute) { double('Fog::Compute::Cloudstack') }
+  let(:ui) { double('Vagrant::UI') }
+  let(:service) { CloudstackResourceService.new(cloudstack_compute, ui) }
+
+  before do
+    response = {
+      'listkindsresponse' => {
+        'kind' => [{ 'id' => 'resource id', 'name' => 'resource name' }]
+      }
+    }
+    allow(cloudstack_compute).to receive(:send).with(:list_kinds, { 'id' => 'resource id' }).and_return(response)
+    allow(cloudstack_compute).to receive(:send).with(:list_kinds, {}).and_return(response)
+
+    allow(ui).to receive(:detail)
+    allow(ui).to receive(:info)
+  end
+
+  describe '#sync_resource' do
+    it 'retrives the missing name' do
+      resource = CloudstackResource.new('resource id', nil, 'kind')
+      expect(service.sync_resource(resource)).to be_eql 'resource name'
+    end
+
+    it 'retrives the missing id' do
+      resource = CloudstackResource.new(nil, 'resource name', 'kind')
+      expect(service.sync_resource(resource)).to be_eql 'resource id'
+    end
+  end
+end


### PR DESCRIPTION
This PR builds on top of PR #90 (please review/merge that one first).

Refactor some of the configuration variables from run_instance action into resource objects.
This way two variables (_id and _name) are replaced with an object that encapsulates the two.
The enriching of these resource objects is done in a service object that knows how to query the cloudstack API to retrieve them.

This refactoring has introduced some duplication, and in order to remove that, security groups also have to be refactored in the same way. Then the respective private methods in the run_instance action can be removed.
