### PR TITLE
Replace File.open by File.read to ensure fast closing of files.

### DIFF
--- a/lib/vagrant-cloudstack/action/terminate_instance.rb
+++ b/lib/vagrant-cloudstack/action/terminate_instance.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_cloudstack.deleting_firewall_rule"))
           firewall_file = env[:machine].data_dir.join("firewall")
           if firewall_file.file?
-            File.open(firewall_file, "r").each_line do |line|
+            File.read(firewall_file).each_line do |line|
               rule_id = line.strip
               begin
                 options = {
@@ -43,7 +43,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_cloudstack.disabling_static_nat"))
           static_nat_file = env[:machine].data_dir.join("static_nat")
           if static_nat_file.file?
-            File.open(static_nat_file, "r").each_line do |line|
+            File.read(static_nat_file).each_line do |line|
               ip_address_id = line.strip
               begin
                 options = {
@@ -71,7 +71,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_cloudstack.deleting_port_forwarding_rule"))
           port_forwarding_file = env[:machine].data_dir.join("port_forwarding")
           if port_forwarding_file.file?
-            File.open(port_forwarding_file, "r").each_line do |line|
+            File.read(port_forwarding_file).each_line do |line|
               rule_id = line.strip
               begin
                 resp = env[:cloudstack_compute].delete_port_forwarding_rule({:id => rule_id})
@@ -122,7 +122,7 @@ module VagrantPlugins
 
           security_groups_file = env[:machine].data_dir.join("security_groups")
           if security_groups_file.file?
-            File.open(security_groups_file, "r").each_line do |line|
+            File.read(security_groups_file).each_line do |line|
               security_group_id = line.strip
               begin
                 security_group = env[:cloudstack_compute].security_groups.get(security_group_id)


### PR DESCRIPTION
This blocks/breaks (immediate) removal of status files (firewall, port_forwarding, ...)
at least on Windows where handles are not closed
untill script/Vagrant(Ruby) has stopped.

Also see issue #97 
