### PR TITLE
Open Firewall to trusted networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_public_port` - Public port for port forwarding rule
 * `pf_private_port` - Private port for port forwarding rule
 * `pf_open_firewall` - Flag to enable/disable automatic open firewall rule
+* `pf_trusted_networks` - CIDRList to network(s) to open firewall for (default 0.0.0.0/0)
 * `port_forwarding_rules` - Port forwarding rules for the virtual machine
 * `firewall_rules` - Firewall rules
 * `display_name` - Display name for the instance
@@ -306,6 +307,8 @@ Vagrant.configure("2") do |config|
       { :ipaddress => "X.X.X.X", :cidrlist  => "1.2.3.4/24", :protocol => "tcp", :startport => 22, :endport => 22 },
       { :ipaddress => "X.X.X.X", :cidrlist  => "1.2.3.4/24", :protocol => "tcp", :startport => 80, :endport => 80 },
     ]
+
+    cloudstack.pf_trusted_networks = "1.2.3.4/24,11.22.33.44/32"
   end
 end
 ```

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -4,8 +4,6 @@ require 'vagrant-cloudstack/exceptions/exceptions'
 require 'vagrant-cloudstack/util/timer'
 require 'vagrant-cloudstack/model/cloudstack_resource'
 require 'vagrant-cloudstack/service/cloudstack_resource_service'
-require "pry"
-
 
 module VagrantPlugins
   module Cloudstack

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -4,6 +4,8 @@ require 'vagrant-cloudstack/exceptions/exceptions'
 require 'vagrant-cloudstack/util/timer'
 require 'vagrant-cloudstack/model/cloudstack_resource'
 require 'vagrant-cloudstack/service/cloudstack_resource_service'
+require "pry"
+
 
 module VagrantPlugins
   module Cloudstack
@@ -46,6 +48,7 @@ module VagrantPlugins
           pf_public_port        = domain_config.pf_public_port
           pf_private_port       = domain_config.pf_private_port
           pf_open_firewall      = domain_config.pf_open_firewall
+          pf_trusted_networks   = domain_config.pf_trusted_networks
           port_forwarding_rules = domain_config.port_forwarding_rules
           firewall_rules        = domain_config.firewall_rules
           display_name          = domain_config.display_name
@@ -198,9 +201,23 @@ module VagrantPlugins
               :protocol     => 'tcp',
               :publicport   => pf_public_port,
               :privateport  => pf_private_port,
-              :openfirewall => pf_open_firewall
+              :openfirewall => (pf_open_firewall and pf_trusted_networks) ? false : pf_open_firewall
             }
             create_port_forwarding_rule(env, port_forwarding_rule)
+
+            if pf_open_firewall and pf_trusted_networks
+              # Allow access to public port from trusted networks only
+              fw_rule_trusted_networks = {
+                  :ipaddressid  => pf_ip_address_id,
+                  :ipaddress    => pf_ip_address,
+                  :protocol     => "tcp",
+                  :startport    => pf_public_port,
+                  :endport      => pf_public_port,
+                  :cidrlist     => pf_trusted_networks
+              }
+              firewall_rules = [] unless firewall_rules
+              firewall_rules << fw_rule_trusted_networks
+            end
           end
 
           if !port_forwarding_rules.empty?

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -146,6 +146,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :pf_open_firewall
 
+      # CIDR List string of trusted networks
+      #
+      # @return [String]
+      attr_accessor :pf_trusted_networks
+
       # comma separated list of port forwarding rules
       # (hash with rule parameters)
       #
@@ -249,6 +254,7 @@ module VagrantPlugins
         @pf_public_port            = UNSET_VALUE
         @pf_private_port           = UNSET_VALUE
         @pf_open_firewall          = UNSET_VALUE
+        @pf_trusted_networks       = UNSET_VALUE
         @port_forwarding_rules     = UNSET_VALUE
         @firewall_rules            = UNSET_VALUE
         @security_group_ids        = UNSET_VALUE
@@ -410,6 +416,9 @@ module VagrantPlugins
 
         # Open firewall is true by default (for backwards compatibility)
         @pf_open_firewall       = true if @pf_open_firewall == UNSET_VALUE
+
+        # Trusted networks must be nil, since we can't default that
+        @pf_trusted_networks    = nil if @pf_trusted_networks == UNSET_VALUE
 
         # Port forwarding rules  must be empty array
         @port_forwarding_rules  = [] if @port_forwarding_rules == UNSET_VALUE

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -37,6 +37,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_public_port")         { should be_nil  }
     its("pf_private_port")        { should be_nil  }
     its("pf_open_firewall")       { should == true }
+    its("pf_trusted_networks")    { should == []   }
     its("port_forwarding_rules")  { should == []   }
     its("firewall_rules")         { should == []   }
     its("security_group_ids")     { should == []   }
@@ -143,6 +144,7 @@ describe VagrantPlugins::Cloudstack::Config do
     let(:config_pf_public_port)         { "foo" }
     let(:config_pf_private_port)        { "foo" }
     let(:config_pf_open_firewall)       { false }
+    let(:config_pf_trusted_networks)    { "foo" }
     let(:config_port_forwarding_rules)  { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_firewall_rules)         { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_security_group_ids)     { ["foo", "bar"] }
@@ -179,6 +181,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_public_port         = config_pf_public_port
       instance.pf_private_port        = config_pf_private_port
       instance.pf_open_firewall       = config_pf_open_firewall
+      instance.pf_trusted_networks    = config_pf_trusted_networks
       instance.port_forwarding_rules  = config_port_forwarding_rules
       instance.firewall_rules         = config_firewall_rules
       instance.security_group_ids     = config_security_group_ids
@@ -231,6 +234,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_ip_address")          { should == config_pf_ip_address }
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
+      its("pf_trusted_networks")    { should == config_pf_trusted_networks}
       its("pf_open_firewall")       { should == config_pf_open_firewall }
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
@@ -284,6 +288,7 @@ describe VagrantPlugins::Cloudstack::Config do
       its("pf_public_port")         { should == config_pf_public_port }
       its("pf_private_port")        { should == config_pf_private_port }
       its("pf_open_firewall")       { should == config_pf_open_firewall }
+      its("pf_trusted_networks")    { should == config_pf_trusted_networks}
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
       its("security_group_ids")     { should == config_security_group_ids }

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -37,7 +37,7 @@ describe VagrantPlugins::Cloudstack::Config do
     its("pf_public_port")         { should be_nil  }
     its("pf_private_port")        { should be_nil  }
     its("pf_open_firewall")       { should == true }
-    its("pf_trusted_networks")    { should == []   }
+    its("pf_trusted_networks")    { should be_nil  }
     its("port_forwarding_rules")  { should == []   }
     its("firewall_rules")         { should == []   }
     its("security_group_ids")     { should == []   }


### PR DESCRIPTION
Due to the CloudStack API, Open firewall (pf_open_firewall) defaults to opening to the world.

This PR introduces a new property, pf_trusted_networks, which contains a CIDR list.
If this property is filled, the pf_open_firewall will be limited to this list.
