### PR TITLE
Enhance firewall/portforward rules usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_public_port_randomrange` - If public port is omited, a port from this range wll be used (default `{:start=>49152, :end=>65535}`)
 * `pf_private_port` - Private port for port forwarding rule (defaults to respective Communicator protocol)
 * `pf_open_firewall` - Flag to enable/disable automatic open firewall rule (by CloudStack)
-* `pf_trusted_networks` - Array to network(s) to automatically generate firewall rules for
+* `pf_trusted_networks` - Array to network(s) to 
+  - automatically (by plugin) generate firewall rules for, ignored if `pf_open_firewall` set `true`
+  - use as default for firewall rules where source CIDR is missing
 * `port_forwarding_rules` - Port forwarding rules for the virtual machine
 * `firewall_rules` - Firewall rules
 * `display_name` - Display name for the instance

--- a/README.md
+++ b/README.md
@@ -294,18 +294,28 @@ Vagrant.configure("2") do |config|
 
     cloudstack.port_forwarding_rules = [
       { :ipaddress => "X.X.X.X", :protocol => "tcp", :publicport => 22, :privateport  => 22, :openfirewall => false },
-      { :ipaddress => "X.X.X.X", :protocol => "tcp", :publicport => 80, :privateport  => 80, :openfirewall => false },
+      { :ipaddress => "X.X.X.X", :protocol => "tcp", :publicport => 80, :privateport  => 80, :openfirewall => false }
     ]
 
     cloudstack.firewall_rules = [
       { :ipaddress => "A.A.A.A", :cidrlist  => "1.2.3.4/24", :protocol => "icmp", :icmptype => 8, :icmpcode => 0 },
       { :ipaddress => "X.X.X.X", :cidrlist  => "1.2.3.4/24", :protocol => "tcp", :startport => 22, :endport => 22 },
-      { :ipaddress => "X.X.X.X", :cidrlist  => "1.2.3.4/24", :protocol => "tcp", :startport => 80, :endport => 80 },
+      { :ipaddress => "X.X.X.X", :cidrlist  => "1.2.3.4/24", :protocol => "tcp", :startport => 80, :endport => 80 }
     ]
 
   end
 end
 ```
+Most values in the firewall and portforwarding rules are not mandatory, except either startport/endport or privateport/publicport
+* `:ipaddress` - defaults to `pf_ip_address`
+* `:protocol` - defaults to `'tcp'`
+* `:publicport` - defaults to `:privateport`
+* `:privateport` - defaults to `:publicport`
+* `:openfirewall` - defaults to `pf_open_firewall`
+* `:cidrlist` - defaults to `pf_trusted_networks`
+* `:startport` - defaults to `:endport`
+* `:endport` - not required by CloudStack
+
 
 For only allowing Vagrant to access the box for further provisioning (SSH/WinRM), and opening the Firewall for some subnets, the following config is sufficient:
 ```ruby
@@ -313,13 +323,30 @@ Vagrant.configure("2") do |config|
   # ... other stuff
 
   config.vm.provider :cloudstack do |cloudstack|
-    cloudstack.pf_open_firewall      = "true"
+    cloudstack.pf_open_firewall      = "false"
     cloudstack.pf_ip_address         = X.X.X.X
     cloudstack.pf_trusted_networks   = [ "1.2.3.4/24" , "11.22.33.44/32" ]
   end
 end
 ```
 Where X.X.X.X is the ip of the respective CloudStack network, this will automatically map the port of the used Communicator (SSH/Winrm) via a random public port, open the Firewall and set Vagrant to use it.
+
+The plugin can also automatically generate firewall rules off of the portforwarding  rules:
+```ruby
+Vagrant.configure("2") do |config|
+  # ... other stuff
+
+  config.vm.provider :cloudstack do |cloudstack|
+
+    cloudstack.pf_trusted_networks   = [ "1.2.3.4/24" , "11.22.33.44/32" ]
+    cloudstack.port_forwarding_rules = [
+      { :privateport  => 22, :generate_firewall => true },
+      { :privateport  => 80, :generate_firewall => true }
+    ]
+
+  end
+end
+```
 
 ## Synced Folders
 

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -275,13 +275,28 @@ module VagrantPlugins
           if !port_forwarding_rules.empty?
             port_forwarding_rules.each do |port_forwarding_rule|
               port_forwarding_rule[:ipaddressid]  = pf_ip_address_id                    if port_forwarding_rule[:ipaddressid].nil?
-              port_forwarding_rule[:ipaddress]  = pf_ip_address                    if port_forwarding_rule[:ipaddress].nil?
+              port_forwarding_rule[:ipaddress]    = pf_ip_address                       if port_forwarding_rule[:ipaddress].nil?
               port_forwarding_rule[:protocol]     = 'tcp'                               if port_forwarding_rule[:protocol].nil?
               port_forwarding_rule[:openfirewall] = pf_open_firewall                    if port_forwarding_rule[:openfirewall].nil?
               port_forwarding_rule[:publicport]   = port_forwarding_rule[:privateport]  if port_forwarding_rule[:publicport].nil?
               port_forwarding_rule[:privateport]  = port_forwarding_rule[:publicport]   if port_forwarding_rule[:privateport].nil?
 
               create_port_forwarding_rule(env, port_forwarding_rule)
+
+              if port_forwarding_rule[:generate_firewall] && pf_trusted_networks
+                # Allow access to public port from trusted networks only
+                fw_rule_trusted_networks = {
+                    :ipaddressid  => port_forwarding_rule[:ipaddressid],
+                    :ipaddress    => port_forwarding_rule[:ipaddress],
+                    :protocol     => port_forwarding_rule[:protocol],
+                    :startport    => port_forwarding_rule[:publicport],
+                    :endport      => port_forwarding_rule[:publicport],
+                    :cidrlist     => pf_trusted_networks.join(',')
+                }
+                firewall_rules = [] unless firewall_rules
+                firewall_rules << fw_rule_trusted_networks
+              end
+
             end
           end
 

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -283,7 +283,7 @@ module VagrantPlugins
 
               create_port_forwarding_rule(env, port_forwarding_rule)
 
-              if port_forwarding_rule[:generate_firewall] && pf_trusted_networks
+              if port_forwarding_rule[:generate_firewall] && pf_trusted_networks && !port_forwarding_rule[:openfirewall]
                 # Allow access to public port from trusted networks only
                 fw_rule_trusted_networks = {
                     :ipaddressid  => port_forwarding_rule[:ipaddressid],

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -213,7 +213,7 @@ module VagrantPlugins
               :protocol     => 'tcp',
               :publicport   => pf_public_port,
               :privateport  => pf_private_port,
-              :openfirewall => (pf_open_firewall && pf_trusted_networks) ? false : pf_open_firewall
+              :openfirewall => pf_open_firewall
             }
 
             pf_public_port = domain_config.pf_public_port = create_randomport_forwarding_rule(
@@ -223,12 +223,12 @@ module VagrantPlugins
               'pf_public_port'
             )
 
-            if pf_open_firewall && pf_trusted_networks
+            if pf_trusted_networks && !pf_open_firewall
               # Allow access to public port from trusted networks only
               fw_rule_trusted_networks = {
                   :ipaddressid  => pf_ip_address_id,
                   :ipaddress    => pf_ip_address,
-                  :protocol     => "tcp",
+                  :protocol     => 'tcp',
                   :startport    => pf_public_port,
                   :endport      => pf_public_port,
                   :cidrlist     => pf_trusted_networks.join(',')
@@ -247,7 +247,7 @@ module VagrantPlugins
               :protocol     => 'tcp',
               :publicport   => pf_public_rdp_port,
               :privateport  => pf_private_rdp_port,
-              :openfirewall => (pf_open_firewall && pf_trusted_networks) ? false : pf_open_firewall
+              :openfirewall => pf_open_firewall
             }
 
             pf_public_rdp_port = domain_config.pf_public_rdp_port = create_randomport_forwarding_rule(
@@ -257,12 +257,12 @@ module VagrantPlugins
               'pf_public_rdp_port'
             )
 
-            if pf_open_firewall && pf_trusted_networks
+            if pf_trusted_networks  && !pf_open_firewall
               # Allow access to public port from trusted networks only
               fw_rule_trusted_networks = {
                   :ipaddressid  => pf_ip_address_id,
                   :ipaddress    => pf_ip_address,
-                  :protocol     => "tcp",
+                  :protocol     => 'tcp',
                   :startport    => pf_public_rdp_port,
                   :endport      => pf_public_rdp_port,
                   :cidrlist     => pf_trusted_networks.join(',')
@@ -274,12 +274,25 @@ module VagrantPlugins
 
           if !port_forwarding_rules.empty?
             port_forwarding_rules.each do |port_forwarding_rule|
+              port_forwarding_rule[:ipaddressid]  = pf_ip_address_id                    if port_forwarding_rule[:ipaddressid].nil?
+              port_forwarding_rule[:ipaddress]  = pf_ip_address                    if port_forwarding_rule[:ipaddress].nil?
+              port_forwarding_rule[:protocol]     = 'tcp'                               if port_forwarding_rule[:protocol].nil?
+              port_forwarding_rule[:openfirewall] = pf_open_firewall                    if port_forwarding_rule[:openfirewall].nil?
+              port_forwarding_rule[:publicport]   = port_forwarding_rule[:privateport]  if port_forwarding_rule[:publicport].nil?
+              port_forwarding_rule[:privateport]  = port_forwarding_rule[:publicport]   if port_forwarding_rule[:privateport].nil?
+
               create_port_forwarding_rule(env, port_forwarding_rule)
             end
           end
 
           if !firewall_rules.empty?
             firewall_rules.each do |firewall_rule|
+              firewall_rule[:ipaddressid] = pf_ip_address_id              if firewall_rule[:ipaddressid].nil?
+              firewall_rule[:ipaddress]   = pf_ip_address                 if firewall_rule[:ipaddress].nil?
+              firewall_rule[:cidrlist]    = pf_trusted_networks.join(',') if firewall_rule[:cidrlist].nil?
+              firewall_rule[:protocol]    = 'tcp'                         if firewall_rule[:protocol].nil?
+              firewall_rule[:startport]   = firewall_rule[:endport]       if firewall_rule[:startport].nil?
+
               create_firewall_rule(env, firewall_rule)
             end
           end


### PR DESCRIPTION
Fixes #120 ; pf_open_firewall is passed to ACS, but blocks firewall rule generation if set
Fixes #115 ; Use pf_trusted_networks as default cidrlist for Firewall rules

Values in firewall rules have default values, see README
Values in portforwarding rules have default values, see README

Firewall rules can be generated by passing `:generate_firewall => true` in the portforwarding rule
