### PR TITLE
Generate SSH keypair for lifetime of VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `template_name` - Template name to use for the instance, defaults to Vagrants config.vm.box
 * `zone_id` - Zone uuid to launch the instance into
 * `zone_name` - Zone uuid to launch the instance into
-* `keypair` - SSH keypair name
+* `keypair` - SSH keypair name, if neither'keypair' nor 'ssh_key' have been specified, a temporary keypair will be created
 * `static_nat` - static nat for the virtual machine
 * `pf_ip_address_id` - IP address ID for port forwarding rule
 * `pf_ip_address` - IP address for port forwarding rule

--- a/lib/vagrant-cloudstack/action/read_ssh_info.rb
+++ b/lib/vagrant-cloudstack/action/read_ssh_info.rb
@@ -63,6 +63,13 @@ module VagrantPlugins
             end
           end
 
+          if domain_config.keypair.nil? && domain_config.ssh_key.nil?
+            sshkeyfile_file = machine.data_dir.join('sshkeyfile')
+            if sshkeyfile_file.file?
+              domain_config.ssh_key = sshkeyfile_file.to_s
+            end
+          end
+
           ssh_info = {
                        :host => pf_ip_address || server.nics[0]['ipaddress'],
                        :port => pf_public_port

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,9 +4,9 @@ en:
       The machine is already %{status}.
     launching_instance: |-
       Launching an instance with the following settings...
-    launch_no_keypair: |-
-      Warning! You didn't specify a keypair to launch your instance with.
-      This can sometimes result in not being able to access your instance.
+    launch_no_keypair_no_sshkey: |-
+      No keypair or ssh_key specified to launch your instance with.
+      Generating a temporary keypair for this instance...
     launch_vpc_warning: |-
       Warning! You're launching this instance into a VPC without an
       elastic IP. Please verify you're properly connected to a VPN so
@@ -21,6 +21,12 @@ en:
       Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
+    ssh_key_pair_creating: |-
+      Creating an SSH keypair in CloudStack...
+    ssh_key_pair_removing: |-
+      Deleting the SSH keypair in CloudStack...
+    ssh_key_pair_no_success_removing: |-
+      Removing SSH keypair returned unsuccesful (keypair name: %{name})
     starting: |-
       Starting the instance...
     stopping: |-


### PR DESCRIPTION
Fixes #124 

To test this, just leave out both 'ssh_key' and 'keypair'.

But be sure to leave in your bootstrap user in 'ssh_user' (if anything other then 'vagrant' :wink:)
