### PR TITLE
Add vpc support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
   gem 'rspec-its'
   gem 'rspec-mocks'
   gem 'pry-byebug'
+  gem 'mash'
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,11 @@ group :development do
   gem 'coveralls', require: false
   gem 'simplecov', require: false
   gem 'rspec-core'
+  gem 'rspec-collection_matchers'
   gem 'rspec-expectations'
   gem 'rspec-its'
   gem 'rspec-mocks'
+  gem 'pry-byebug'
 end
 
 group :plugins do

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Vagrant.configure("2") do |config|
     cloudstack.network_id = "AAAAAAAAAAAAAAAAAAA"
     cloudstack.zone_id = "AAAAAAAAAAAAAAAAAAA"
     cloudstack.project_id = "AAAAAAAAAAAAAAAAAAA"
-    cloudstack.network_type = "Advanced" # or "Basic"
   end
 end
 ```
@@ -82,7 +81,6 @@ Vagrant.configure("2") do |config|
     cloudstack.name = "doge-is-a-hostname-now"
     # Sadly there is currently no support for the project api in fog.
     cloudstack.project_id = "AAAAAAAAAAAAAAAAAAA"
-    cloudstack.network_type = "Advanced" # or "Basic"
   end
 end
 ```
@@ -130,7 +128,6 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `domain_id` - Domain id to launch the instance into
 * `network_id` - Network uuid that the instance should use
 * `network_name` - Network name that the instance should use
-* `network_type` - CloudStack Network Type(default: Advanced)
 * `project_id` - Project uuid that the instance should belong to
 * `service_offering_id`- Service offering uuid to use for the instance
 * `service_offering_name`- Service offering name to use for the instance
@@ -147,7 +144,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_public_port_randomrange` - If public port is omited, a port from this range wll be used (default `{:start=>49152, :end=>65535}`)
 * `pf_private_port` - Private port for port forwarding rule (defaults to respective Communicator protocol)
 * `pf_open_firewall` - Flag to enable/disable automatic open firewall rule (by CloudStack)
-* `pf_trusted_networks` - Array to network(s) to 
+* `pf_trusted_networks` - Array to network(s) to
   - automatically (by plugin) generate firewall rules for, ignored if `pf_open_firewall` set `true`
   - use as default for firewall rules where source CIDR is missing
 * `port_forwarding_rules` - Port forwarding rules for the virtual machine
@@ -213,8 +210,7 @@ the Cloudstack machine.
 
 ### Basic Networking
 
-If you set the `network_type` to `basic`, you can use Security
-Groups and associate rules in your Vagrantfile.
+In a basic networking zone you can use Security Groups and associate rules in your Vagrantfile.
 
 If you already have Security Groups, you can associate them to your
 instance, with their IDs:
@@ -226,7 +222,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_group_ids = ['aaaa-bbbb-cccc-dddd', '1111-2222-3333-4444']
   end
 end
@@ -241,7 +236,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_group_names = ['
 min_fantastiska_security_group', 'another_security_grupp']
   end
@@ -257,7 +251,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_groups = [
       {
         :name         => "Awesome_security_group",

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.require_version '>= 1.5.0'
+
+machines = {
+  'fixed-pub-port-box' => {
+    'public_port'         => ENV['PUBLIC_SSH_PORT'],
+    'private_port'        => ENV['PRIVATE_SSH_PORT'],
+    'pf_trusted_networks' => [ENV['SOURCE_CIDR']],
+    'template'            => ENV['LINUX_TEMPLATE_NAME'],
+    'communicator'        => 'ssh',
+    'rsync_disabled'      => true
+  },
+  'random-pub-port-box' => {
+    'pf_public_port_randomrange' => { start: 10000, end: 10010 },
+    'private_port'               => ENV['PRIVATE_SSH_PORT'],
+    'pf_trusted_networks'        => [ENV['SOURCE_CIDR']],
+    'template'                   => ENV['LINUX_TEMPLATE_NAME'],
+    'communicator'               => 'ssh',
+    'rsync_disabled'             => true
+  }
+}
+
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
+  machines.each_pair do |name, options|
+    global_config.vm.define name do |config|
+      config.vm.box = options['template']
+
+      config.vm.communicator = options['communicator']
+      config.vm.synced_folder ".", "/vagrant", type: "rsync",
+        rsync__exclude: [".git/", "vendor"], disabled: options['rsync_disabled']
+      config.vm.provider :cloudstack do |cloudstack, override|
+
+        cloudstack.display_name = ENV['TEST_NAME']
+
+        cloudstack.host       = ENV['CLOUDSTACK_HOST']
+        cloudstack.path       = '/client/api'
+        cloudstack.port       = '443'
+        cloudstack.scheme     = 'https'
+        cloudstack.api_key    = ENV['CLOUDSTACK_API_KEY']
+        cloudstack.secret_key = ENV['CLOUDSTACK_SECRET_KEY']
+
+        public_source_nat_ip = ENV['PUBLIC_SOURCE_NAT_IP']
+
+        cloudstack.zone_name             = ENV['ZONE_NAME']
+        cloudstack.network_name          = ENV['NETWORK_NAME']
+        cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
+
+        cloudstack.network_type          = 'Advanced'
+        cloudstack.pf_ip_address         = public_source_nat_ip
+
+        cloudstack.pf_public_port             = options['public_port']
+        cloudstack.pf_public_port_randomrange = options['pf_public_port_randomrange']
+        cloudstack.pf_private_port            = options['private_port']
+        cloudstack.pf_open_firewall           = false
+        cloudstack.pf_trusted_networks        = options['pf_trusted_networks']
+
+        unless ENV['SSH_KEY'].nil?
+            cloudstack.ssh_key               = ENV['SSH_KEY']
+            cloudstack.ssh_user              = ENV['SSH_USER']
+        end
+
+        unless ENV['WINDOWS_USER'].nil?
+            cloudstack.vm_user = ENV['WINDOWS_USER']
+        end
+      end
+    end
+  end
+end

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -17,6 +17,24 @@ machines = {
     'communicator'        => 'ssh',
     'rsync_disabled'      => true
   },
+  'no-priv-port-linux-box' => {
+    'network_name'               => ENV['NETWORK_NAME'],
+    'public_ip'                  => ENV['PUBLIC_SOURCE_NAT_IP'],
+    'pf_public_port_randomrange' => { start: 10000, end: 10010 },
+    'pf_trusted_networks'        => [ENV['SOURCE_CIDR']],
+    'template'                   => ENV['LINUX_TEMPLATE_NAME'],
+    'communicator'               => 'ssh',
+    'rsync_disabled'             => true
+  },
+  'no-priv-port-windows-box' => {
+    'network_name'               => ENV['NETWORK_NAME'],
+    'public_ip'                  => ENV['PUBLIC_SOURCE_NAT_IP'],
+    'pf_public_port_randomrange' => { start: 10000, end: 10010 },
+    'pf_trusted_networks'        => [ENV['SOURCE_CIDR']],
+    'template'                   => ENV['WINDOWS_TEMPLATE_NAME'],
+    'communicator'               => 'winrm',
+    'rsync_disabled'             => true
+  },
   'random-pub-port-box' => {
     'network_name'               => ENV['NETWORK_NAME'],
     'public_ip'                  => ENV['PUBLIC_SOURCE_NAT_IP'],

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -8,6 +8,8 @@ Vagrant.require_version '>= 1.5.0'
 
 machines = {
   'fixed-pub-port-box' => {
+    'network_name'        => ENV['NETWORK_NAME'],
+    'public_ip'           => ENV['PUBLIC_SOURCE_NAT_IP'],
     'public_port'         => ENV['PUBLIC_SSH_PORT'],
     'private_port'        => ENV['PRIVATE_SSH_PORT'],
     'pf_trusted_networks' => [ENV['SOURCE_CIDR']],
@@ -16,7 +18,19 @@ machines = {
     'rsync_disabled'      => true
   },
   'random-pub-port-box' => {
+    'network_name'               => ENV['NETWORK_NAME'],
+    'public_ip'                  => ENV['PUBLIC_SOURCE_NAT_IP'],
     'pf_public_port_randomrange' => { start: 10000, end: 10010 },
+    'private_port'               => ENV['PRIVATE_SSH_PORT'],
+    'pf_trusted_networks'        => [ENV['SOURCE_CIDR']],
+    'template'                   => ENV['LINUX_TEMPLATE_NAME'],
+    'communicator'               => 'ssh',
+    'rsync_disabled'             => true
+  },
+  'vpc-box' => {
+    'network_name'               => ENV['VPC_TIER_NAME'],
+    'public_ip'                  => ENV['VPC_PUBLIC_IP'],
+    'pf_public_port_randomrange' => { start: 2200, end: 2220 },
     'private_port'               => ENV['PRIVATE_SSH_PORT'],
     'pf_trusted_networks'        => [ENV['SOURCE_CIDR']],
     'template'                   => ENV['LINUX_TEMPLATE_NAME'],
@@ -45,14 +59,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
         cloudstack.api_key    = ENV['CLOUDSTACK_API_KEY']
         cloudstack.secret_key = ENV['CLOUDSTACK_SECRET_KEY']
 
-        public_source_nat_ip = ENV['PUBLIC_SOURCE_NAT_IP']
-
         cloudstack.zone_name             = ENV['ZONE_NAME']
-        cloudstack.network_name          = ENV['NETWORK_NAME']
+        cloudstack.network_name          = options['network_name']
         cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
 
         cloudstack.network_type          = 'Advanced'
-        cloudstack.pf_ip_address         = public_source_nat_ip
+        cloudstack.pf_ip_address         = options['public_ip']
 
         cloudstack.pf_public_port             = options['public_port']
         cloudstack.pf_public_port_randomrange = options['pf_public_port_randomrange']

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -55,6 +55,17 @@ machines = {
     'communicator'               => 'ssh',
     'rsync_disabled'             => true
   }
+  # The no-pf-box is commented out becuse in the current test setup we do not
+  # have the ability to open up a network in such a way that we can reach a box
+  # without port forwarding rules. However, this can be usefull when creating a box
+  # from within the same netowkr or VPC.
+  #,
+  # 'no-pf-box' => {
+  #   'network_name'               => ENV['NETWORK_NAME'],
+  #   'template'                   => ENV['LINUX_TEMPLATE_NAME'],
+  #   'communicator'               => 'ssh',
+  #   'rsync_disabled'             => true
+  # }
 }
 
 

--- a/functional-tests/networking/test.bats
+++ b/functional-tests/networking/test.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+vagrant_up() {
+  bundle exec vagrant up
+}
+
+vagrant_destroy() {
+  bundle exec vagrant destroy -f
+}
+
+teardown() {
+  run vagrant_destroy
+}
+
+@test "create and destroy vm" {
+  run vagrant_up
+  [ $status = 0 ]
+
+  run vagrant_destroy
+  [ $status = 0 ]
+}
+

--- a/functional-tests/rsync/Vagrantfile.advanced_networking
+++ b/functional-tests/rsync/Vagrantfile.advanced_networking
@@ -27,7 +27,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cloudstack.network_name          = ENV['NETWORK_NAME']
     cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
 
-    cloudstack.network_type          = 'Advanced'
     cloudstack.pf_ip_address         = public_source_nat_ip
     cloudstack.pf_public_port        = public_ssh_port
     cloudstack.pf_private_port       = ENV['PRIVATE_SSH_PORT']

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -37,7 +37,6 @@ module VagrantPlugins
           @template         = CloudstackResource.new(domain_config.template_id, domain_config.template_name || env[:machine].config.vm.box, 'template')
 
           hostname                    = domain_config.name
-          network_type                = domain_config.network_type
           project_id                  = domain_config.project_id
           keypair                     = domain_config.keypair
           static_nat                  = domain_config.static_nat

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -13,9 +13,6 @@ module VagrantPlugins
       # This runs the configured instance.
       class RunInstance
         include Vagrant::Util::Retryable
-        # include VagrantPlugins::Cloudstack::Model
-        # include VagrantPlugins::Cloudstack::Service
-        # include VagrantPlugins::Cloudstack::Exceptions
 
         def initialize(app, env)
           @app                  = app

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -187,6 +187,7 @@ module VagrantPlugins
 
           networkingConfig.pf_private_rdp_port = pf_private_rdp_port
 
+          vm_guest = env[:machine].config.vm.guest || :linux
           if networkingConfig.pf_private_port.nil?
             communicator = env[:machine].communicate.instance_variable_get('@logger').instance_variable_get('@name')
             comm_obj = env[:machine].config.send(communicator)
@@ -194,9 +195,9 @@ module VagrantPlugins
             networkingConfig.pf_private_port = comm_obj.port if comm_obj.respond_to?('port')
             networkingConfig.pf_private_port = comm_obj.guest_port if comm_obj.respond_to?('guest_port')
             networkingConfig.pf_private_port = comm_obj.default.port if (comm_obj.respond_to?('default') && comm_obj.default.respond_to?('port'))
+            # networkingConfig.pf_private_port ||= vm_guest == :linux ? '22' : '5985'
           end
 
-          vm_guest = env[:machine].config.vm.guest || :linux
           if networkingConfig.needs_public_port?
             random_public_port = create_randomport_forwarding_rule(
               env,

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -59,11 +59,6 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :network_name
 
-      # Network Type
-      #
-      # @return [String]
-      attr_accessor :network_type
-
       # Project uuid that the instance should belong to
       #
       # @return [String]
@@ -249,7 +244,6 @@ module VagrantPlugins
         @domain_id                 = UNSET_VALUE
         @network_id                = UNSET_VALUE
         @network_name              = UNSET_VALUE
-        @network_type              = UNSET_VALUE
         @project_id                = UNSET_VALUE
         @service_offering_id       = UNSET_VALUE
         @service_offering_name     = UNSET_VALUE
@@ -383,9 +377,6 @@ module VagrantPlugins
 
         # Network uuid must be nil, since we can't default that
         @network_name           = nil if @network_name == UNSET_VALUE
-
-        # NetworkType is 'Advanced' by default
-        @network_type           = "Advanced" if @network_type == UNSET_VALUE
 
         # Project uuid must be nil, since we can't default that
         @project_id             = nil if @project_id == UNSET_VALUE

--- a/lib/vagrant-cloudstack/exceptions/exceptions.rb
+++ b/lib/vagrant-cloudstack/exceptions/exceptions.rb
@@ -1,9 +1,11 @@
 module VagrantPlugins
   module Cloudstack
     module Exceptions
-      class IpNotFoundException < Exception
+      class NoIpProvidedException < Exception
       end
       class DuplicatePFRule < Exception
+      end
+      class ApiCommandFailed < Exception
       end
     end
   end

--- a/lib/vagrant-cloudstack/model/cloudstack_network_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_network_resource.rb
@@ -1,0 +1,22 @@
+module VagrantPlugins
+  module Cloudstack
+    module Model
+      class CloudstackNetworkResource < CloudstackResource
+        attr_accessor :acl_id
+
+        def initialize(id, name)
+          super(id, name, 'network')
+        end
+
+        def is_vpc?
+          !acl_id.nil?
+        end
+
+        def to_s
+          kind = is_vpc? ? 'VPC tier' : 'Guest network'
+          "#{kind} - #{id || '<unknown id>'}:#{name || '<unknown name>'}"
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
@@ -48,6 +48,10 @@ module VagrantPlugins
           !portforwarding_port_range.nil?
         end
 
+        def has_pf_ip_address?
+          !(@pf_ip_address_id || @pf_ip_address).nil?
+        end
+
         def port_forwarding_rule(vm_guest)
           {
             :network      => @network,
@@ -103,10 +107,6 @@ module VagrantPlugins
         end
 
         private
-
-        def has_pf_ip_address?
-          !(@pf_ip_address_id || @pf_ip_address).nil?
-        end
 
         def has_pf_public_port?
           !@pf_public_port.nil?

--- a/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
@@ -7,13 +7,13 @@ module VagrantPlugins
                     :pf_ip_address,
                     :pf_public_port,
                     :pf_public_rdp_port,
-                    :pf_private_port,
                     :pf_public_port_randomrange,
                     :pf_open_firewall,
                     :pf_trusted_networks,
                     :security_groups,
                     :private_ip_address
         attr_accessor :network,
+                      :pf_private_port,
                       :pf_private_rdp_port,
                       :pf_public_rdp_port,
                       :default_port_forwarding_rule_created

--- a/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
@@ -13,7 +13,8 @@ module VagrantPlugins
                     :pf_trusted_networks,
                     :security_groups,
                     :private_ip_address
-        attr_accessor :pf_private_rdp_port,
+        attr_accessor :network,
+                      :pf_private_rdp_port,
                       :pf_public_rdp_port,
                       :default_port_forwarding_rule_created
 
@@ -49,6 +50,7 @@ module VagrantPlugins
 
         def port_forwarding_rule(vm_guest)
           {
+            :network      => @network,
             :ipaddressid  => @pf_ip_address_id,
             :ipaddress    => @pf_ip_address,
             :protocol     => 'tcp',
@@ -116,6 +118,7 @@ module VagrantPlugins
 
         def enhance_firewall_rules
           @firewall_rules.each do |rule|
+            rule[:network]     ||= @network
             rule[:ipaddressid] ||= @pf_ip_address_id
             rule[:ipaddress]   ||= @pf_ip_address
             rule[:cidrlist]    ||= trusted_networks_cidrlist

--- a/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_networking_config.rb
@@ -1,0 +1,183 @@
+module VagrantPlugins
+  module Cloudstack
+    module Model
+      class CloudstackNetworkingConfig
+        attr_reader :static_nat,
+                    :pf_ip_address_id,
+                    :pf_ip_address,
+                    :pf_public_port,
+                    :pf_public_rdp_port,
+                    :pf_private_port,
+                    :pf_public_port_randomrange,
+                    :pf_open_firewall,
+                    :pf_trusted_networks,
+                    :security_groups,
+                    :private_ip_address
+        attr_accessor :pf_private_rdp_port,
+                      :pf_public_rdp_port
+
+        def initialize(config)
+          @static_nat                 = config.static_nat
+          @pf_ip_address_id           = config.pf_ip_address_id
+          @pf_ip_address              = config.pf_ip_address
+          @pf_public_port             = config.pf_public_port
+          @pf_public_rdp_port         = config.pf_public_rdp_port
+          @pf_public_port_randomrange = config.pf_public_port_randomrange
+          @pf_private_port            = config.pf_private_port
+          @pf_open_firewall           = config.pf_open_firewall
+          @pf_trusted_networks        = config.pf_trusted_networks   || []
+          @port_forwarding_rules      = config.port_forwarding_rules || []
+          @firewall_rules             = config.firewall_rules        || []
+          @security_groups            = config.security_groups       || []
+          @private_ip_address         = config.private_ip_address
+        end
+
+        def needs_public_port?
+          !(has_pf_public_port? || has_pf_public_rdp_port?)
+        end
+
+        def has_portforwarding?
+          has_pf_ip_address? && has_pf_public_port?
+        end
+
+        def port_forwarding_rule(vm_guest)
+          {
+            :ipaddressid  => @pf_ip_address_id,
+            :ipaddress    => @pf_ip_address,
+            :protocol     => 'tcp',
+            :publicport   => public_port(vm_guest),
+            :privateport  => private_port(vm_guest),
+            :openfirewall => @pf_open_firewall
+          }
+        end
+
+        def portforwarding_port_range
+          @pf_public_port_randomrange[:start]...@pf_public_port_randomrange[:end]
+        end
+
+        def should_open_firewall_to_trusted_networks?
+          !(@pf_trusted_networks.empty? || @pf_open_firewall)
+        end
+
+        def firewall_rules
+          extended_firewall_rules = enhance_firewall_rules
+          if should_open_firewall_to_trusted_networks?
+            extended_firewall_rules << {
+                :ipaddressid  => @pf_ip_address_id,
+                :ipaddress    => @pf_ip_address,
+                :protocol     => 'tcp',
+                :startport    => @pf_public_port,
+                :endport      => @pf_public_port,
+                :cidrlist     => @pf_trusted_networks.join(',')
+            }
+
+            extended_firewall_rules + firewall_rules_from_port_forwarding
+          end
+          extended_firewall_rules
+        end
+
+        def port_forwarding_rules(vm_guest)
+          rules = enhance_port_forwarding_rules
+          rules << port_forwarding_rule(vm_guest) if rules.empty?
+          rules
+        end
+
+        def udpate_public_port(vm_guest, public_port)
+          case vm_guest
+          when :windows
+            @pf_public_rdp_port = public_port
+          when :linux
+            @pf_public_port = public_port
+          else
+            raise "Unexpected vm guest #{vm_guest}"
+          end
+        end
+
+        private
+
+        def has_pf_ip_address?
+          !(@pf_ip_address_id || @pf_ip_address).nil?
+        end
+
+        def has_pf_public_port?
+          !(@pf_public_port || @pf_public_port_randomrange).nil?
+        end
+
+        def has_pf_public_rdp_port?
+          !(@pf_public_rdp_port || @pf_public_port_randomrange).nil?
+        end
+
+        def enhance_firewall_rules
+          @firewall_rules.each do |rule|
+            rule[:ipaddressid] ||= @pf_ip_address_id
+            rule[:ipaddress]   ||= @pf_ip_address
+            rule[:cidrlist]    ||= @pf_trusted_networks.join(',')
+            rule[:protocol]    ||= 'tcp'
+            rule[:endport]     ||= rule[:startport]
+          end
+        end
+
+        def firewall_rules_from_port_forwarding
+          rules = []
+          enhance_port_forwarding_rules.each do |rule|
+            if rule[:generate_firewall] && !rule[:openfirewall]
+              rules << {
+                :ipaddressid  => rule[:ipaddressid],
+                :ipaddress    => rule[:ipaddress],
+                :protocol     => rule[:protocol],
+                :startport    => rule[:publicport],
+                :endport      => rule[:publicport],
+                :cidrlist     => @pf_trusted_networks.join(',')
+              }
+            end
+          end
+          rules
+        end
+
+        def enhance_port_forwarding_rules
+          @port_forwarding_rules.each do |rule|
+            rule[:ipaddressid]  ||= @pf_ip_address_id
+            rule[:ipaddress]    ||= @pf_ip_address
+            rule[:protocol]     ||= 'tcp'
+            rule[:openfirewall] ||= @pf_open_firewall
+            rule[:publicport]   ||= rule[:privateport]
+            rule[:privateport]  ||= rule[:publicport]
+          end
+        end
+
+        def firewall_rule_truested_networks
+          {
+            :ipaddressid  => @pf_ip_address_id,
+            :ipaddress    => @pf_ip_address,
+            :protocol     => 'tcp',
+            :startport    => @pf_public_port,
+            :endport      => @pf_public_port,
+            :cidrlist     => @pf_trusted_networks.join(',')
+          }
+        end
+
+        def private_port(vm_guest)
+          case vm_guest
+          when :windows
+            @pf_private_rdp_port
+          when :linux
+            @pf_private_port
+          else
+            raise "Unexpected vm guest #{vm_guest}"
+          end
+        end
+
+        def public_port(vm_guest)
+          case vm_guest
+          when :windows
+            @pf_public_rdp_port
+          when :linux
+            @pf_public_port
+          else
+            raise "Unexpected vm guest #{vm_guest}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
         attr_reader   :kind
 
         def initialize(id, name, kind)
-          raise 'Resource must have a kind' if kind.nil? || kind.empty?
+          raise ArgumentError, 'Resource must have a kind' if kind.nil? || kind.empty?
           @id             = id
           @name           = name
           @kind           = kind
@@ -26,6 +26,19 @@ module VagrantPlugins
 
         def to_s
           "#{kind} - #{id || '<unknown id>'}:#{name || '<unknown name>'}"
+        end
+
+        def unsynched(another_resource)
+          self == another_resource ||
+          (self.kind == another_resource.kind && \
+          (self.id   == another_resource.id   && another_resource.name.nil?) || \
+          (self.name == another_resource.name && another_resource.id.nil?))
+        end
+
+        def ==(another_resource)
+          self.id   == another_resource.id   && \
+          self.name == another_resource.name && \
+          self.kind == another_resource.kind
         end
       end
     end

--- a/lib/vagrant-cloudstack/service/base_service.rb
+++ b/lib/vagrant-cloudstack/service/base_service.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module Cloudstack
+    module Service
+      class BaseService
+        def initialize(cloudstack_compute, ui)
+          @cloudstack_compute = cloudstack_compute
+          @ui                 = ui
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/service/cloudstack_networking_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_networking_service.rb
@@ -1,0 +1,139 @@
+require 'vagrant-cloudstack/service/base_service'
+require 'vagrant-cloudstack/exceptions/exceptions'
+require 'fog'
+
+module VagrantPlugins
+  module Cloudstack
+    module Service
+      class CloudstackNetworkingService < BaseService
+        include VagrantPlugins::Cloudstack::Exceptions
+
+        def initialize(cloudstack_compute, ui, machine)
+          super(cloudstack_compute, ui)
+          @machine = machine
+        end
+
+        def enable_static_nat(ip_address)
+          options = {
+            :command          => 'enableStaticNat',
+            :ipaddressid      => ip_address.id,
+            :virtualmachineid => @machine.id
+          }
+
+          begin
+            # TODO: use fog API to enable static nat
+            #       https://github.com/fog/fog/blob/b2c6e0df30eae7fb9154ba6bd340f27c0c158855/lib/fog/cloudstack/requests/compute/enable_static_nat.rb
+            resp = @cloudstack_compute.request(options)
+            is_success = resp['enablestaticnatresponse']['success']
+
+            if is_success != 'true'
+              raise ApiCommandFailed, resp['enablestaticnatresponse']['errortext']
+            end
+            @ui.info('Static NAT enabled')
+            save_ip_address_to_data_dir(ip_address.id)
+          rescue Fog::Compute::Cloudstack::Error => e
+            raise Errors::FogError, :message => e.message
+          end
+        end
+
+        def create_port_forwarding_rule(rule, ip_address)
+          options = {
+              :ipaddressid      => ip_address.id,
+              :publicport       => rule[:publicport],
+              :privateport      => rule[:privateport],
+              :protocol         => rule[:protocol],
+              :openfirewall     => rule[:openfirewall],
+              :virtualmachineid => @machine.id
+          }
+
+          begin
+            resp   = @cloudstack_compute.create_port_forwarding_rule(options)
+            job_id = resp['createportforwardingruleresponse']['jobid']
+
+            raise ApiCommandFailed, resp['enablestaticnatresponse']['errortext'] if job_id.nil?
+
+            # TODO: there should be a timeout or a max retry value
+            # TODO: the code should handle a failed job result (or will that always throw a FOG exception?)
+            while true
+              response = @cloudstack_compute.query_async_job_result({ :jobid => job_id })
+              if response['queryasyncjobresultresponse']['jobstatus'] != 0
+                break
+              else
+                sleep 2
+              end
+            end
+            @ui.info('Port forwarding rule created')
+            port_forwarding_rule = response['queryasyncjobresultresponse']['jobresult']['portforwardingrule']
+            save_port_forwarding_to_data_dir(port_forwarding_rule['id'])
+          rescue Fog::Compute::Cloudstack::Error => e
+            raise Errors::FogError, :message => e.message
+          end
+        end
+
+        def create_firewall_rule(rule, ip_address)
+          options = {
+              :command     => 'createFirewallRule',
+              :ipaddressid => ip_address.id,
+              :protocol    => rule[:protocol],
+              :cidrlist    => rule[:cidrlist],
+              :startport   => rule[:startport],
+              :endport     => rule[:endport],
+              :icmpcode    => rule[:icmpcode],
+              :icmptype    => rule[:icmptype]
+          }
+
+          begin
+            # TODO: use fog API to create firewall rule
+            #       https://github.com/fog/fog/blob/b2c6e0df30eae7fb9154ba6bd340f27c0c158855/lib/fog/cloudstack/requests/compute/create_firewall_rule.rb
+            resp = @cloudstack_compute.request(options)
+            job_id = resp['createfirewallruleresponse']['jobid']
+
+            raise ApiCommandFailed, resp['createfirewallruleresponse']['errortext'] if job_id.nil?
+
+            # TODO: there should be a timeout or a max retry value
+            # TODO: the code should handle a failed job result (or will that always throw a FOG exception?)
+            while true
+              response = @cloudstack_compute.query_async_job_result({ :jobid => job_id })
+              if response['queryasyncjobresultresponse']['jobstatus'] != 0
+                break
+              else
+                sleep 2
+              end
+            end
+            @ui.info('Firewall rule created')
+            firewall_rule = response['queryasyncjobresultresponse']['jobresult']['firewallrule']
+            save_firewall_rule_to_data_dir(firewall_rule['id'])
+          rescue Fog::Compute::Cloudstack::Error => e
+            if e.message =~ /The range specified,.*conflicts with rule/
+              @ui.warn("Failed to create firewall rule: #{e.message}")
+            else
+              raise Errors::FogError, :message => e.message
+            end
+          end
+        end
+
+        private
+
+        def save_firewall_rule_to_data_dir(rule_id)
+          save_element_to_data_dir('firewall', rule_id)
+        end
+
+        def save_port_forwarding_to_data_dir(rule_id)
+          save_element_to_data_dir('port_forwarding', rule_id)
+        end
+
+        def save_ip_address_to_data_dir(ip_address_id)
+          save_element_to_data_dir('static_nat', ip_address_id)
+        end
+
+        def save_element_to_data_dir(element_name, value)
+          element_file = @machine.data_dir.join(element_name)
+          element_file.open('a+') do |f|
+            f.write("#{value}\n")
+            f.close()
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
@@ -1,19 +1,31 @@
 require 'vagrant-cloudstack/service/base_service'
+require 'vagrant-cloudstack/model/cloudstack_network_resource'
 
 module VagrantPlugins
   module Cloudstack
     module Service
       class CloudstackResourceService < BaseService
         def sync_resource(resource, api_parameters = {})
+          @resource_details = nil
           if resource.id.nil? and resource.name
             resource.id = name_to_id(resource.name, resource.kind, api_parameters)
           elsif resource.id
             resource.name = id_to_name(resource.id, resource.kind, api_parameters)
           end
-          @ui.detail("Syncronized resource: #{resource}")
+
+          unless resource.is_undefined?
+            read_acl_id(resource)
+            @ui.detail("Syncronized resource: #{resource}")
+          end
         end
 
         private
+
+        def read_acl_id(resource)
+          if resource.is_a? Model::CloudstackNetworkResource
+            resource.acl_id = @resource_details['aclid']
+          end
+        end
 
         def translate_from_to(resource_type, options)
           if resource_type == 'public_ip_address'
@@ -28,16 +40,17 @@ module VagrantPlugins
 
         def resourcefield_to_id(resource_type, resource_field, resource_field_value, options={})
           @ui.info("Fetching UUID for #{resource_type} with #{resource_field} '#{resource_field_value}'")
-          full_response = translate_from_to(resource_type, options)
-          result        = full_response.find {|type| type[resource_field] == resource_field_value }
-          result['id']
+          full_response     = translate_from_to(resource_type, options)
+          @resource_details = full_response.find {|type| type[resource_field] == resource_field_value }
+          @resource_details['id']
         end
 
         def id_to_resourcefield(resource_id, resource_type, resource_field, options={})
           @ui.info("Fetching #{resource_field} for #{resource_type} with UUID '#{resource_id}'")
           options = options.merge({'id' => resource_id})
           full_response = translate_from_to(resource_type, options)
-          full_response[0][resource_field]
+          @resource_details = full_response[0]
+          @resource_details[resource_field]
         end
 
         def name_to_id(resource_name, resource_type, options={})

--- a/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
+++ b/lib/vagrant-cloudstack/service/cloudstack_resource_service.rb
@@ -1,12 +1,9 @@
+require 'vagrant-cloudstack/service/base_service'
+
 module VagrantPlugins
   module Cloudstack
     module Service
-      class CloudstackResourceService
-        def initialize(cloudstack_compute, ui)
-          @cloudstack_compute = cloudstack_compute
-          @ui                 = ui
-        end
-
+      class CloudstackResourceService < BaseService
         def sync_resource(resource, api_parameters = {})
           if resource.id.nil? and resource.name
             resource.id = name_to_id(resource.name, resource.kind, api_parameters)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 require 'coveralls'
 require 'rspec/its'
 require 'rspec/collection_matchers'
+require 'mash'
 
 SimpleCov.start
 Coveralls.wear!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 require 'rspec/its'
+require 'rspec/collection_matchers'
 
 SimpleCov.start
 Coveralls.wear!

--- a/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
@@ -73,6 +73,34 @@ describe CloudstackNetworkingConfig do
     end
   end
 
+  describe '#has_pf_ip_address?' do
+    it 'returns true if pf_ip_address_id is defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id' => 'some ip address id'
+        }
+      ))
+
+      expect(config.has_pf_ip_address?).to eq(true)
+    end
+
+    it 'returns true if pf_ip_address is defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address' => 'some ip address'
+        }
+      ))
+
+      expect(config.has_pf_ip_address?).to eq(true)
+    end
+
+    it 'returns false if neither pf_ip_address_id or pf_ip_address are defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new({}))
+
+      expect(config.has_pf_ip_address?).to eq(false)
+    end
+  end
+
   describe '#port_forwarding_rule' do
     it 'returns a SSH port forwarding rule for linux guests' do
       config = CloudstackNetworkingConfig.new(ConfigMock.new(

--- a/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
@@ -87,6 +87,7 @@ describe CloudstackNetworkingConfig do
 
       expect(config.port_forwarding_rule(:linux)).to eq(
         {
+          :network      => nil,
           :ipaddressid  => 'some ip address id',
           :ipaddress    => 'some ip address',
           :protocol     => 'tcp',
@@ -110,6 +111,7 @@ describe CloudstackNetworkingConfig do
 
       expect(config.port_forwarding_rule(:windows)).to eq(
         {
+          :network      => nil,
           :ipaddressid  => 'some ip address id',
           :ipaddress    => 'some ip address',
           :protocol     => 'tcp',
@@ -194,6 +196,7 @@ describe CloudstackNetworkingConfig do
 
     it 'enhances rules with missing attributes' do
       rule1 = {
+        :network     => nil,
         :ipaddressid => 'some ip address id',
         :ipaddress   => 'some ip address',
         :cidrlist    => 'first trusted net,second trusted net',
@@ -318,8 +321,9 @@ describe CloudstackNetworkingConfig do
       expect(actual).to include(rule1, rule2)
     end
 
-    it 'introduces a default portforwarding rule' do
+    it 'introduces a default port forwarding rule' do
       rule1 = {
+        :network      => nil,
         :ipaddressid  => 'some ip address id',
         :ipaddress    => 'some ip address',
         :protocol     => 'tcp',

--- a/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_networking_config_spec.rb
@@ -1,0 +1,351 @@
+require 'spec_helper'
+require 'vagrant-cloudstack/model/cloudstack_networking_config'
+
+include VagrantPlugins::Cloudstack::Model
+
+class ConfigMock
+  attr_accessor :static_nat,
+                :pf_ip_address_id,
+                :pf_ip_address,
+                :pf_public_port,
+                :pf_public_rdp_port,
+                :pf_public_port_randomrange,
+                :pf_private_port,
+                :pf_private_rdp_port,
+                :pf_open_firewall,
+                :pf_trusted_networks,
+                :port_forwarding_rules,
+                :firewall_rules,
+                :security_groups,
+                :private_ip_address
+
+  def initialize(values)
+    values.each_pair do |key, value|
+      send(:"#{key}=", value)
+    end
+  end
+end
+
+describe CloudstackNetworkingConfig do
+  describe '#has_portforwarding?' do
+    it 'returns true if pf_ip_address_id and pf_public_port are defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id' => 'some ip address id',
+          'pf_public_port'   => 'some public port'
+        }
+      ))
+
+      expect(config.has_portforwarding?).to eq(true)
+    end
+
+    it 'returns true if pf_ip_address_id and pf_public_port_randomrange are defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id'             => 'some ip address id',
+          'pf_public_port_randomrange'   => { :start => 1, :end => 2 }
+        }
+      ))
+
+      expect(config.has_portforwarding?).to eq(true)
+    end
+
+    it 'returns true if pf_ip_address and pf_public_port are defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address'    => 'some ip address',
+          'pf_public_port'   => 'some public port'
+        }
+      ))
+
+      expect(config.has_portforwarding?).to eq(true)
+    end
+
+    it 'returns true if pf_ip_address_id and pf_public_port_randomrange are defined' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address'                => 'some ip address',
+          'pf_public_port_randomrange'   => { :start => 1, :end => 2 }
+        }
+      ))
+
+      expect(config.has_portforwarding?).to eq(true)
+    end
+  end
+
+  describe '#port_forwarding_rule' do
+    it 'returns a SSH port forwarding rule for linux guests' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id' => 'some ip address id',
+          'pf_ip_address'    => 'some ip address',
+          'pf_public_port'   => 2222,
+          'pf_private_port'  => 22,
+          'pf_open_firewall' => true
+        }
+      ))
+
+      expect(config.port_forwarding_rule(:linux)).to eq(
+        {
+          :ipaddressid  => 'some ip address id',
+          :ipaddress    => 'some ip address',
+          :protocol     => 'tcp',
+          :publicport   => 2222,
+          :privateport  => 22,
+          :openfirewall => true
+        }
+      )
+    end
+
+    it 'returns a RDP port forwarding rule for linux guests' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id'     => 'some ip address id',
+          'pf_ip_address'        => 'some ip address',
+          'pf_open_firewall'     => true
+        }
+      ))
+      config.pf_public_rdp_port  = 33890
+      config.pf_private_rdp_port = 3389
+
+      expect(config.port_forwarding_rule(:windows)).to eq(
+        {
+          :ipaddressid  => 'some ip address id',
+          :ipaddress    => 'some ip address',
+          :protocol     => 'tcp',
+          :publicport   => 33890,
+          :privateport  => 3389,
+          :openfirewall => true
+        }
+      )
+    end
+  end
+
+  describe '#portforwarding_port_range' do
+    it 'returns a ruby range value' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_public_port_randomrange'   => { :start => 1, :end => 2 }
+        }
+      ))
+
+      expect(config.portforwarding_port_range).to eq(1...2)
+    end
+  end
+
+  describe '#should_open_firewall_to_trusted_networks?' do
+    it 'returns true if pf_trusted_networks is not empty and pf_open_firewall is false' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_trusted_networks' => ['some network'],
+          'pf_open_firewall' => false
+        }
+      ))
+
+      expect(config.should_open_firewall_to_trusted_networks?).to eq(true)
+    end
+
+    it 'returns false if pf_trusted_networks is empyy' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new({}))
+
+      expect(config.should_open_firewall_to_trusted_networks?).to eq(false)
+    end
+
+    it 'returns false if pf_open_firewall is true' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_open_firewall' => true
+        }
+      ))
+
+      expect(config.should_open_firewall_to_trusted_networks?).to eq(false)
+    end
+  end
+
+  describe '#firewall_rules' do
+    it 'returns explicit firewall rules only' do
+      rule1 = {
+        :ipaddressid => 'some ip address id',
+        :ipaddress   => 'some ip address',
+        :cidrlist    => 'some cidrlist',
+        :protocol    => 'tcp',
+        :startport   => 1,
+        :endport     => 2
+      }
+      rule2 = {
+        :ipaddressid => 'some other ip address id',
+        :ipaddress   => 'some other ip address',
+        :cidrlist    => 'some other cidrlist',
+        :protocol    => 'tcp',
+        :startport   => 10,
+        :endport     => 20
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'firewall_rules' => [rule1, rule2]
+        }
+      ))
+
+      actual = config.firewall_rules
+
+      expect(actual).to have_exactly(2).items
+      expect(actual).to contain_exactly(rule1, rule2)
+    end
+
+    it 'enhances rules with missing attributes' do
+      rule1 = {
+        :ipaddressid => 'some ip address id',
+        :ipaddress   => 'some ip address',
+        :cidrlist    => 'first trusted net,second trusted net',
+        :protocol    => 'tcp',
+        :startport   => 1,
+        :endport     => 1
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'firewall_rules'      => [{ :startport => 1 }],
+          'pf_ip_address_id'    => 'some ip address id',
+          'pf_ip_address'       => 'some ip address',
+          'pf_trusted_networks' => ['first trusted net', 'second trusted net'],
+          'pf_open_firewall'    => true
+        }
+      ))
+
+      actual = config.firewall_rules
+
+      expect(actual).to have_exactly(1).items
+      expect(actual).to include(rule1)
+    end
+
+    it 'adds rules from portforwardings' do
+      rule1 = {
+        :ipaddressid => 'some ip address id',
+        :ipaddress   => 'some ip address',
+        :cidrlist    => 'first trusted net,second trusted net',
+        :protocol    => 'tcp',
+        :startport   => 1,
+        :endport     => 1
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id'    => 'some ip address id',
+          'pf_ip_address'       => 'some ip address',
+          'pf_public_port'      => 1,
+          'pf_trusted_networks' => ['first trusted net', 'second trusted net'],
+          'pf_open_firewall'    => false
+        }
+      ))
+
+      actual = config.firewall_rules
+
+      expect(actual).to have_exactly(1).items
+      expect(actual).to include(rule1)
+    end
+  end
+
+  describe '#port_forwarding_rules' do
+    it 'returns the portforwarding rules' do
+      rule1 = {
+        :ipaddressid  => 'some ip address id',
+        :ipaddress    => 'some ip address',
+        :protocol     => 'tcp',
+        :publicport   => 1,
+        :privateport  => 2,
+        :openfirewall => true
+      }
+      rule2 = {
+        :ipaddressid  => 'some other ip address id',
+        :ipaddress    => 'some other ip address',
+        :protocol     => 'tcp',
+        :publicport   => 10,
+        :privateport  => 20,
+        :openfirewall => false
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'port_forwarding_rules' => [rule1, rule2]
+        }
+      ))
+
+      actual = config.port_forwarding_rules(:linux)
+
+      expect(actual).to have_exactly(2).items
+      expect(actual).to include(rule1, rule2)
+    end
+
+    it 'enhances the portforwarding rules' do
+      rule1 = {
+        :ipaddressid  => 'some ip address id',
+        :ipaddress    => 'some ip address',
+        :protocol     => 'tcp',
+        :publicport   => 1,
+        :privateport  => 1,
+        :openfirewall => true
+      }
+      rule2 = {
+        :ipaddressid  => 'some ip address id',
+        :ipaddress    => 'some ip address',
+        :protocol     => 'tcp',
+        :publicport   => 2,
+        :privateport  => 2,
+        :openfirewall => true
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'port_forwarding_rules' => [{ :publicport => 1 }, { :privateport => 2 }],
+          'pf_ip_address_id'      => 'some ip address id',
+          'pf_ip_address'         => 'some ip address',
+          'pf_open_firewall'      => true
+        }
+      ))
+
+      actual = config.port_forwarding_rules(:linux)
+
+      expect(actual).to have_exactly(2).items
+      expect(actual).to include(rule1, rule2)
+    end
+
+    it 'introduces a default portforwarding rule' do
+      rule1 = {
+        :ipaddressid  => 'some ip address id',
+        :ipaddress    => 'some ip address',
+        :protocol     => 'tcp',
+        :publicport   => 2222,
+        :privateport  => 22,
+        :openfirewall => true
+      }
+      config = CloudstackNetworkingConfig.new(ConfigMock.new(
+        {
+          'pf_ip_address_id' => 'some ip address id',
+          'pf_ip_address'    => 'some ip address',
+          'pf_public_port'   => 2222,
+          'pf_private_port'  => 22,
+          'pf_open_firewall' => true
+        }
+      ))
+
+      actual = config.port_forwarding_rules(:linux)
+
+      expect(actual).to have_exactly(1).items
+      expect(actual).to include(rule1)
+    end
+  end
+
+  describe '#udpate_public_port' do
+    it 'updates the SSH public port' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new({}))
+
+      config.udpate_public_port(:linux, 1)
+
+      expect(config.pf_public_port).to eq(1)
+    end
+
+    it 'updates the RDP public port' do
+      config = CloudstackNetworkingConfig.new(ConfigMock.new({}))
+
+      config.udpate_public_port(:windows, 1)
+
+      expect(config.pf_public_rdp_port).to eq(1)
+    end
+  end
+end

--- a/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
@@ -29,11 +29,11 @@ describe CloudstackResource do
   context 'when kind is not defined' do
     describe '#new' do
       it 'raises an error when kind is nil' do
-        expect { CloudstackResource.new('id', 'name', nil) }.to raise_error('Resource must have a kind')
+        expect { CloudstackResource.new('id', 'name', nil) }.to raise_error(ArgumentError, 'Resource must have a kind')
       end
 
       it 'raises an error when kind is empty' do
-        expect { CloudstackResource.new('id', 'name', '') }.to raise_error('Resource must have a kind')
+        expect { CloudstackResource.new('id', 'name', '') }.to raise_error(ArgumentError, 'Resource must have a kind')
       end
     end
   end

--- a/spec/vagrant-cloudstack/service/cloudstack_networking_service_spec.rb
+++ b/spec/vagrant-cloudstack/service/cloudstack_networking_service_spec.rb
@@ -56,6 +56,7 @@ describe CloudstackNetworkingService do
         allow(cloudstack_compute).to receive(:create_port_forwarding_rule).and_return(create_pf_response)
         allow(cloudstack_compute).to receive(:query_async_job_result).with({ :jobid => pf_job_id }).and_return(async_pf_job_reponse)
         rule = {
+          :network      => Mash.new('id' => 'network id'),
           :publicport   => 1,
           :privateport  => 2,
           :protocol     => 'tcp',
@@ -105,6 +106,48 @@ describe CloudstackNetworkingService do
 
         expect(service).to receive(:save_firewall_rule_to_data_dir)
         service.create_firewall_rule(rule, ip)
+      end
+    end
+
+    describe '#create_network_acl' do
+      it 'creates a network ACL rule' do
+        acl_command = {
+          :aclid       => 'acl id',
+          :networkid   => 'network id',
+          :action      => 'Allow',
+          :protocol    => 'tcp',
+          :cidrlist    => 'a cidr list',
+          :startport   => 1,
+          :endport     => 2,
+          :icmpcode    => 'icmp code',
+          :icmptype    => 'icmp type',
+          :traffictype => 'Ingress'
+        }
+        acl_job_id = '3'
+        create_acl_response = { 'createnetworkaclresponse' => { 'jobid' => acl_job_id }}
+        async_acl_job_reponse = {
+          'queryasyncjobresultresponse' => {
+            'jobstatus' => 1,
+            'jobresult' => {
+              'networkacl' => {
+                'id' => 'acl_rule_id'
+              }
+            }
+          }
+        }
+        allow(cloudstack_compute).to receive(:create_network_acl).with(acl_command).and_return(create_acl_response)
+        allow(cloudstack_compute).to receive(:query_async_job_result).with({ :jobid => acl_job_id }).and_return(async_acl_job_reponse)
+        rule = {
+          :protocol    => 'tcp',
+          :cidrlist    => 'a cidr list',
+          :startport   => 1,
+          :endport     => 2,
+          :icmpcode    => 'icmp code',
+          :icmptype    => 'icmp type',
+        }
+
+        expect(service).to receive(:save_network_acl_to_data_dir)
+        service.create_network_acl(rule, Mash.new('id' => 'network id', 'acl_id' => 'acl id'))
       end
     end
   end

--- a/spec/vagrant-cloudstack/service/cloudstack_networking_service_spec.rb
+++ b/spec/vagrant-cloudstack/service/cloudstack_networking_service_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+require 'pathname'
+require 'vagrant-cloudstack/model/cloudstack_resource'
+require 'vagrant-cloudstack/service/cloudstack_networking_service'
+
+include VagrantPlugins::Cloudstack::Model
+include VagrantPlugins::Cloudstack::Service
+include VagrantPlugins::Cloudstack::Exceptions
+
+describe CloudstackNetworkingService do
+  let(:cloudstack_compute) { double('Fog::Compute::Cloudstack') }
+  let(:ui) { double('Vagrant::UI') }
+  let(:machine) { machine = Mash.new({:id => 'machine_id', :data_dir => Pathname.new('dir')}) }
+  let(:service) { CloudstackNetworkingService.new(cloudstack_compute, ui, machine) }
+  let(:ip) { ip = CloudstackResource.new('some ip address id', 'name', 'public_ip') }
+
+  before do
+    allow(ui).to receive(:info)
+    allow(ui).to receive(:debug)
+  end
+
+  context 'when the API call succeeds' do
+    describe '#enable_static_nat' do
+      it 'enables static nat' do
+        snat_command = {
+          :command          => 'enableStaticNat',
+          :ipaddressid      => 'some ip address id',
+          :virtualmachineid => 'machine_id'
+        }
+        snat_response = {
+          'enablestaticnatresponse' => {
+            'success' => 'true'
+          }
+        }
+        allow(cloudstack_compute).to receive(:request).with(snat_command).and_return(snat_response)
+
+        expect(service).to receive(:save_ip_address_to_data_dir)
+        service.enable_static_nat(ip)
+      end
+    end
+
+    describe '#create_port_forwarding_rule' do
+      it 'creates a port forwarding rule' do
+        pf_job_id = '1'
+        create_pf_response = { 'createportforwardingruleresponse' => { 'jobid' => pf_job_id } }
+        async_pf_job_reponse = {
+          'queryasyncjobresultresponse' => {
+            'jobstatus' => 1,
+            'jobresult' => {
+              'portforwardingrule' => {
+                'id' => 'pf_rule_id'
+              }
+            }
+          }
+        }
+        allow(cloudstack_compute).to receive(:create_port_forwarding_rule).and_return(create_pf_response)
+        allow(cloudstack_compute).to receive(:query_async_job_result).with({ :jobid => pf_job_id }).and_return(async_pf_job_reponse)
+        rule = {
+          :publicport   => 1,
+          :privateport  => 2,
+          :protocol     => 'tcp',
+          :openfirewall => true
+        }
+
+        expect(service).to receive(:save_port_forwarding_to_data_dir)
+        service.create_port_forwarding_rule(rule, ip)
+      end
+    end
+
+    describe '#create_firewall_rule' do
+      it 'creates a firewall rule' do
+        fw_command = {
+          :command     => 'createFirewallRule',
+          :ipaddressid => 'some ip address id',
+          :protocol    => 'tcp',
+          :cidrlist    => 'a cidr list',
+          :startport   => 1,
+          :endport     => 2,
+          :icmpcode    => 'icmp code',
+          :icmptype    => 'icmp type'
+        }
+        fw_job_id = '2'
+        create_fw_response = { 'createfirewallruleresponse' => { 'jobid' => fw_job_id }}
+        async_fw_job_reponse = {
+          'queryasyncjobresultresponse' => {
+            'jobstatus' => 1,
+            'jobresult' => {
+              'firewallrule' => {
+                'id' => 'fw_rule_id'
+              }
+            }
+          }
+        }
+        allow(cloudstack_compute).to receive(:request).with(fw_command).and_return(create_fw_response)
+        allow(cloudstack_compute).to receive(:query_async_job_result).with({ :jobid => fw_job_id }).and_return(async_fw_job_reponse)
+        rule = {
+          :ipaddressid => 'some ip address id',
+          :protocol    => 'tcp',
+          :cidrlist    => 'a cidr list',
+          :startport   => 1,
+          :endport     => 2,
+          :icmpcode    => 'icmp code',
+          :icmptype    => 'icmp type'
+        }
+
+        expect(service).to receive(:save_firewall_rule_to_data_dir)
+        service.create_firewall_rule(rule, ip)
+      end
+    end
+  end
+
+  context 'when the API call does not succeed' do
+    before do
+      command = {
+        :command          => 'enableStaticNat',
+        :ipaddressid      => 'id',
+        :virtualmachineid => 'machine_id'
+      }
+      response = {
+        'enablestaticnatresponse' => {
+          'success'   => 'false',
+          'errortext' => 'some error message'
+        }
+      }
+      allow(cloudstack_compute).to receive(:request).with(command).and_return(response)
+    end
+
+    describe '#enable_static_nat' do
+      it 'raises an API failure error' do
+        ip = CloudstackResource.new('id', 'name', 'public_ip')
+
+        expect { service.enable_static_nat(ip) }.to raise_exception(ApiCommandFailed, 'some error message')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds VPC support.

Before adding the functionality, the networking configuration and API calls were refactored into a model and service object, respectively.

The code was tested with:

```
bundle exec rspec spec/
```

and

```
cd functional-tests
./run_tests.sh
```

For the functional tests we need to export some new fields. Current full list is:

```
export CLOUDSTACK_HOST="..."
export CLOUDSTACK_API_KEY="..."
export CLOUDSTACK_SECRET_KEY="..."
export PUBLIC_SOURCE_NAT_IP="..."
export VPC_PUBLIC_IP="..."
export PUBLIC_SSH_PORT="2222"
export PRIVATE_SSH_PORT="22"
export PUBLIC_WINRM_PORT="6010"
export PRIVATE_WINRM_PORT="5985"
export ZONE_NAME="..."
export NETWORK_NAME="..."
export VPC_TIER_NAME="..."
export SERVICE_OFFERING_NAME="..."
export LINUX_TEMPLATE_NAME="..."
export WINDOWS_TEMPLATE_NAME="..."
export OPEN_FIREWALL="false"
export SOURCE_CIDR="..."
export SSH_KEY="/path/to/key..."
export SSH_USER="..."
export WINDOWS_USER="Administrator"
```

The functional tests sometimes fail due to time outs.

Some of the API calls could be best implemented using FOG's methods instead of the free-for-all `request` method. Also the waiting for Async jobs can be improved by adding a timer, our retry count.
And finally, the termination of an instance should iterate over a list of resources that were created when an instance is created, and destroy those. I will create issues for these improvements.
