### PR TITLE
Fog 1.32.0 / ACS requires comma separated string for lists

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -129,7 +129,7 @@ module VagrantPlugins
             }
 
             options['network_ids'] = @network.id unless @network.id.nil?
-            options['security_group_ids'] = security_group_ids unless security_group_ids.nil?
+            options['security_group_ids'] = security_group_ids.join(',') unless security_group_ids.nil?
             options['project_id'] = project_id unless project_id.nil?
             options['key_name']   = keypair unless keypair.nil?
             options['name']       = hostname unless hostname.nil?


### PR DESCRIPTION
This behaviour changed apparently between Fog 1.22.0 vs 1.32.0.

New version of Fog was used with vagrant-cloudstack 1.2.0, commit 6a9bbc1cb8863e1a488af02ac62e8182a78214f5
