### PR TITLE
Fix for #82: ignoring network_id if using Basic networking

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -128,7 +128,7 @@ module VagrantPlugins
                 :image_id     => @template.id
             }
 
-            options['network_ids'] = @network.id unless @network.id.nil?
+            options['network_ids'] = @network.id unless @network.id.nil? || network_type == 'Basic'
             options['security_group_ids'] = security_group_ids.join(',') unless security_group_ids.nil?
             options['project_id'] = project_id unless project_id.nil?
             options['key_name']   = keypair unless keypair.nil?


### PR DESCRIPTION
Network ID shouldn't be used with Basic Networking, so if we're using Basic Networking and a network_id is set, we should just ignore it.

This should not change anything if Advanced Networking is used, or if no network ID is set when using Basic Networking.
