### PR TITLE
Only use sec groups if enabled, don't use networks in Basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_groups = [
       {
         :name         => "Awesome_security_group",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Vagrant.configure("2") do |config|
     cloudstack.network_id = "AAAAAAAAAAAAAAAAAAA"
     cloudstack.zone_id = "AAAAAAAAAAAAAAAAAAA"
     cloudstack.project_id = "AAAAAAAAAAAAAAAAAAA"
-    cloudstack.network_type = "Advanced" # or "Basic"
   end
 end
 ```
@@ -82,7 +81,6 @@ Vagrant.configure("2") do |config|
     cloudstack.name = "doge-is-a-hostname-now"
     # Sadly there is currently no support for the project api in fog.
     cloudstack.project_id = "AAAAAAAAAAAAAAAAAAA"
-    cloudstack.network_type = "Advanced" # or "Basic"
   end
 end
 ```
@@ -130,7 +128,6 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `domain_id` - Domain id to launch the instance into
 * `network_id` - Network uuid that the instance should use
 * `network_name` - Network name that the instance should use
-* `network_type` - CloudStack Network Type(default: Advanced)
 * `project_id` - Project uuid that the instance should belong to
 * `service_offering_id`- Service offering uuid to use for the instance
 * `service_offering_name`- Service offering name to use for the instance
@@ -211,9 +208,15 @@ supported with `vagrant-cloudstack`, currently. If any of these are
 specified, Vagrant will emit a warning, but will otherwise boot
 the Cloudstack machine.
 
+### Basic networking versus Advanced networking
+
+The plugin will determine this network type dynamically from the zone.
+The setting `network_type` in the Vagrant file has been deprecated,
+and is silently ignored.
+
 ### Basic Networking
 
-If you set the `network_type` to `basic`, you can use Security
+If the network type of your zone is `basic`, you can use Security
 Groups and associate rules in your Vagrantfile.
 
 If you already have Security Groups, you can associate them to your
@@ -226,7 +229,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_group_ids = ['aaaa-bbbb-cccc-dddd', '1111-2222-3333-4444']
   end
 end
@@ -241,7 +243,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :cloudstack do |cloudstack|
     cloudstack.api_key = "foo"
     cloudstack.secret_key = "bar"
-    cloudstack.network_type = "basic"
     cloudstack.security_group_names = ['
 min_fantastiska_security_group', 'another_security_grupp']
   end

--- a/functional-tests/rsync/Vagrantfile.advanced_networking
+++ b/functional-tests/rsync/Vagrantfile.advanced_networking
@@ -27,7 +27,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cloudstack.network_name          = ENV['NETWORK_NAME']
     cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
 
-    cloudstack.network_type          = 'Advanced'
     cloudstack.pf_ip_address         = public_source_nat_ip
     cloudstack.pf_public_port        = public_ssh_port
     cloudstack.pf_private_port       = ENV['PRIVATE_SSH_PORT']

--- a/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
+++ b/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
@@ -50,7 +50,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
         cloudstack.network_name          = ENV['NETWORK_NAME']
         cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
 
-        cloudstack.network_type          = 'Advanced'
         cloudstack.pf_ip_address         = public_source_nat_ip
 
         cloudstack.pf_public_port        = options['public_port']

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,9 @@ en:
   vagrant_cloudstack:
     already_status: |-
       The machine is already %{status}.
+    basic_network: |-
+      Network name or id defined but zone %{zone_name} is of network type 'Basic'
+      Network name or id will be ignored
     launching_instance: |-
       Launching an instance with the following settings...
     launch_no_keypair_no_sshkey: |-
@@ -21,6 +24,9 @@ en:
       Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
+    security_groups_disabled: |-
+      Security groups defined but not supported in the zone %{zone_name}
+      Defined security groups will be ignored
     ssh_key_pair_creating: |-
       Creating an SSH keypair in CloudStack...
     ssh_key_pair_removing: |-

--- a/vagrant-cloudstack.gemspec
+++ b/vagrant-cloudstack.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version       = VagrantPlugins::Cloudstack::VERSION
   s.platform      = Gem::Platform::RUBY
   s.license       = 'MIT'
-  s.authors       = ['Mitchell Hashimoto', 'Carl Loa Odin', 'Tor-Åke Fransson', 'Olle Lundberg', 'Roeland Kuipers', 'Yuichi Uemura', 'Atsushi Sasaki', 'Nicolas Brechet', 'Peter Jönsson', 'Christophe Roux', 'Andrei Chiriaev', 'Miguel Ferreira', 'Timothy van Zadelhoff', 'Geurt Schimmel']
+  s.authors       = ['Mitchell Hashimoto', 'Carl Loa Odin', 'Tor-Åke Fransson', 'Olle Lundberg', 'Roeland Kuipers', 'Yuichi Uemura', 'Atsushi Sasaki', 'Nicolas Brechet', 'Peter Jönsson', 'Christophe Roux', 'Andrei Chiriaev', 'Miguel Ferreira', 'Timothy van Zadelhoff', 'Geurt Schimmel', 'Bob van den Heuvel']
   s.email         = 'int-toolkit@schubergphilis.com'
   s.homepage      = 'https://github.com/schubergphilis/vagrant-cloudstack/'
   s.summary       = 'Enables Vagrant to manage machines in Cloudstack.'


### PR DESCRIPTION
I.o.w. replaced domain_config.network_type with dynamically detect for network type and support for security groups.
