### PR TITLE
Allways return a port, either generated or specified

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -364,7 +364,7 @@ module VagrantPlugins
               end
             end
           end
-          return rule[:publicport] if pf_public_port.nil?
+          pf_public_port.nil? ? (return rule[:publicport]) : (return pf_public_port)
         end
 
         def store_ssh_keypair(env, domain_config, keyname, account = nil, domainid = nil, projectid = nil)


### PR DESCRIPTION
Closes #137 

The function which generates the public port (if needed) returns that port number and is set to be used by the communicator.
The function now also return the static port if that is specified, thereby setting the communicator now as well
