### PR TITLE
Pull in vagrant gem version 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.8.1'
   gem 'coveralls', require: false
   gem 'simplecov', require: false
   gem 'rspec-core'


### PR DESCRIPTION
This PR pins the version of vagrant gem to the (current) latest release
