### PR TITLE
Allow trusted_networks as both string or array

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `pf_public_port_randomrange` - If public port is omited, a port from this range wll be used (default `{:start=>49152, :end=>65535}`)
 * `pf_private_port` - Private port for port forwarding rule (defaults to respective Communicator protocol)
 * `pf_open_firewall` - Flag to enable/disable automatic open firewall rule (by CloudStack)
-* `pf_trusted_networks` - Array to network(s) to 
+* `pf_trusted_networks` - Array of CIDRs or (array of) comma-separated string of CIDRs to network(s) to 
   - automatically (by plugin) generate firewall rules for, ignored if `pf_open_firewall` set `true`
   - use as default for firewall rules where source CIDR is missing
 * `port_forwarding_rules` - Port forwarding rules for the virtual machine
@@ -338,7 +338,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :cloudstack do |cloudstack|
 
-    cloudstack.pf_trusted_networks   = [ "1.2.3.4/24" , "11.22.33.44/32" ]
+    cloudstack.pf_trusted_networks   = "1.2.3.4/24,11.22.33.44/32"
     cloudstack.port_forwarding_rules = [
       { :privateport  => 22, :generate_firewall => true },
       { :privateport  => 80, :generate_firewall => true }

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ task :default => "spec"
 namespace :functional_tests do
 
   # Name must match folder beneath functional-tests/
-  functional_test_names = %w(vmlifecycle rsync networking)
+  functional_test_names = %w(vmlifecycle networking rsync)
   separate_test_names   = %w(basic)
 
   desc "Check for required enviroment variables for functional testing"

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -5,69 +5,98 @@
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.require_version '>= 1.5.0'
+cloudstack_pf_ip_address = ENV['PUBLIC_SOURCE_NAT_IP']
+machines = {
+  box1: {
+    # Test fixed public port
+    pf_public_port:   ENV['PUBLIC_SSH_PORT'],
+    # Test fixed private port
+    pf_private_port:  ENV['PRIVATE_SSH_PORT'],
+    firewall_rules: [
+        # Full Firewall rule
+        {:ipaddress => cloudstack_pf_ip_address, :protocol => 'tcp', :startport => 1111, :endport => 1111},
+        # Firewall rule without ':ipaddress' which defaults to 'cloudstack_pf_ip_address'
+        {:protocol => 'tcp', :startport => 1122, :endport => 1122},
+        # Firewall rule without ':protocol', which defaults to 'tcp'
+        {:startport => 1133, :endport => 1133},
+        # Firewall rule without ':endport', which defaults to ':startport' if present
+        {:startport => 1144},
+        # Firewall rule without ':start', which defaults to ':endport' if present
+        {:endport => 22}
+    ],
+    port_forwarding_rules: [
+        # Full portforwarding rule
+        {:ipaddress => cloudstack_pf_ip_address, :protocol => "tcp", :publicport => 1111, :privateport => 22, :openfirewall => false},
+        # Portforwarding rule without ':ipaddress' which defaults to 'cloudstack_pf_ip_address'
+        {:protocol => "tcp", :publicport => 1122, :privateport => 22, :openfirewall => false},
+        # Portforwarding rule without ':protocol', which defaults to 'tcp'
+        {:publicport => 1133, :privateport => 22, :openfirewall => false},
+        # Portforwarding rule without ':openfirewall', which defaults to 'cloudstack.pf_open_firewall'
+        {:publicport => 1144, :privateport => 22},
+        # Portforwarding rule without ':publicport', which defaults to ':privateport'
+        {:privateport => 22},
+        # Portforwarding rule with ':generate_firewall', which generates an apropriate
+        # Firewall rule based ':publicport' => ':startport', and other defaults
+        {:publicport => 1155, :privateport => 22, :generate_firewall => true},
+        # Portforwarding rule which instructs CloudStack to create a Firewall rule
+        {:publicport => 1166, :privateport => 22, :openfirewall => true},
+    ],
+    # Trusted network as array, instead of string. Add some networks to make sure it's an (multi element) Array
+    pf_trusted_networks: [ENV['SOURCE_CIDR'], ',172.31.1.172/32', '172.31.1.173/32'],
+    # Ignore security groups
+    security_groups: [{
+                          :name => "Awesome_security_group",
+                          :description => "Created from the Vagrantfile",
+                          :rules => [{:type => "ingress", :protocol => "TCP", :startport => 22, :endport => 22, :cidrlist => "0.0.0.0/0"}]
+                      }],
+    # Ignore security groups
+    security_group_names: ['default', 'Awesome_security_group'],
+  },
+  box2: {
+    # NO pf_public_port; test auto generated public port
+    # NO pf_private_port; test detection of Communicator port (SSH/Winrm)
+    # NO firewall rules for Communicator (SSH/WinRM), test auto generation
+    # Trusted networks as string instead of array. Add some networks to make sure it supports multiple network-string
+    pf_trusted_networks: ENV['SOURCE_CIDR'] + ',172.31.1.172/32,172.31.1.173/32'
+  }
+}
 
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = ENV['LINUX_TEMPLATE_NAME']
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
+  machines.each_pair do |name, options|
+    global_config.vm.define name do |config|
+      config.vm.box = ENV['LINUX_TEMPLATE_NAME']
 
-  config.vm.synced_folder ".", "/vagrant", type: "rsync",
-    rsync__exclude: [".git/", "vendor"], disabled: true
+      config.vm.synced_folder ".", "/vagrant", type: "rsync",
+                              rsync__exclude: [".git/", "vendor"], disabled: true
 
-  config.vm.provider :cloudstack do |cloudstack, override|
-    cloudstack.display_name          = ENV['TEST_NAME']
+      config.vm.provider :cloudstack do |cloudstack, override|
+        cloudstack.display_name = "#{name}-#{ENV['TEST_NAME']}"
 
-    cloudstack.host                  = ENV['CLOUDSTACK_HOST']
-    # Use default path, port and scheme
-    cloudstack.api_key               = ENV['CLOUDSTACK_API_KEY']
-    cloudstack.secret_key            = ENV['CLOUDSTACK_SECRET_KEY']
-    cloudstack.zone_name             = ENV['ZONE_NAME']
-    cloudstack.network_name          = ENV['NETWORK_NAME']
-    cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
-    cloudstack.ssh_key               = ENV['SSH_KEY']  unless ENV['SSH_KEY'].nil?
-    cloudstack.ssh_user              = ENV['SSH_USER'] unless ENV['SSH_USER'].nil?
+        cloudstack.host = ENV['CLOUDSTACK_HOST']
+        # Use default path, port and scheme
+        cloudstack.api_key = ENV['CLOUDSTACK_API_KEY']
+        cloudstack.secret_key = ENV['CLOUDSTACK_SECRET_KEY']
+        cloudstack.zone_name = ENV['ZONE_NAME']
+        cloudstack.network_name = ENV['NETWORK_NAME']
+        cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
+        cloudstack.ssh_key = ENV['SSH_KEY'] unless ENV['SSH_KEY'].nil?
+        cloudstack.ssh_user = ENV['SSH_USER'] unless ENV['SSH_USER'].nil?
+        cloudstack.expunge_on_destroy == true
 
-    cloudstack.pf_ip_address         = ENV['PUBLIC_SOURCE_NAT_IP']
-    cloudstack.pf_public_port        = ENV['PUBLIC_SSH_PORT']
-    cloudstack.pf_private_port       = ENV['PRIVATE_SSH_PORT']
-    cloudstack.pf_open_firewall      = false
+        cloudstack.pf_ip_address = cloudstack_pf_ip_address
+        cloudstack.pf_public_port = options[:pf_public_port]    unless options[:pf_public_port].nil?
+        cloudstack.pf_private_port = options[:pf_private_port]  unless options[:pf_private_port].nil?
+        cloudstack.pf_open_firewall = false
 
-    # With Advanced networking, following Basic networking features should be ignored
-    cloudstack.security_groups       = [{
-      :name         => "Awesome_security_group",
-      :description  => "Created from the Vagrantfile",
-      :rules        => [{:type => "ingress", :protocol => "TCP", :startport => 22, :endport => 22, :cidrlist => "0.0.0.0/0"}]
-    }]
-    cloudstack.security_group_names  = ['default', 'Awesome_security_group']
-    # With Advanced networking, following Basic networking features should be ignored
+        # With Advanced networking, following Basic networking features should be ignored
+        cloudstack.security_groups = options[:security_groups]            unless options[:security_groups].nil?
+        cloudstack.security_group_names = options[:security_group_names]  unless options[:security_group_names].nil?
+        # With Advanced networking, following Basic networking features should be ignored
 
-    cloudstack.pf_trusted_networks   = [ ENV['SOURCE_CIDR'] ]
-    cloudstack.firewall_rules = [
-      # Full Firewall rule
-      { :ipaddress => cloudstack.pf_ip_address, :protocol => 'tcp', :startport => 1111, :endport => 1111 },
-      # Firewall rule without ':ipaddress' which defaults to 'cloudstack.pf_ip_address'
-      { :protocol => 'tcp', :startport => 1122, :endport => 1122 },
-      # Firewall rule without ':protocol', which defaults to 'tcp'
-      { :startport => 1133, :endport => 1133 },
-      # Firewall rule without ':endport', which defaults to ':startport' if present
-      { :startport => 1144 },
-      # Firewall rule without ':start', which defaults to ':endport' if present
-      { :endport => 22 }
-    ]
-    cloudstack.port_forwarding_rules = [
-      # Full portforwarding rule
-      { :ipaddress => cloudstack.pf_ip_address, :protocol => "tcp", :publicport => 1111, :privateport  => 22, :openfirewall => false },
-      # Portforwarding rule without ':ipaddress' which defaults to 'cloudstack.pf_ip_address'
-      { :protocol => "tcp", :publicport => 1122, :privateport  => 22, :openfirewall => false },
-      # Portforwarding rule without ':protocol', which defaults to 'tcp'
-      { :publicport => 1133, :privateport  => 22, :openfirewall => false },
-      # Portforwarding rule without ':openfirewall', which defaults to 'cloudstack.pf_open_firewall'
-      { :publicport => 1144, :privateport  => 22 },
-      # Portforwarding rule without ':publicport', which defaults to ':privateport'
-      { :privateport => 22 },
-      # Portforwarding rule with ':generate_firewall', which generates an apropriate
-      # Firewall rule based ':publicport' => ':startport', and other defaults
-      { :publicport => 1155, :privateport  => 22, :generate_firewall => true },
-      # Portforwarding rule which instructs CloudStack to create a Firewall rule
-      { :publicport => 1166, :privateport  => 22, :openfirewall => true },
-    ]
+        cloudstack.pf_trusted_networks = options[:pf_trusted_networks]      unless options[:pf_trusted_networks].nil?
+        cloudstack.firewall_rules = options[:firewall_rules]                unless options[:firewall_rules].nil?
+        cloudstack.port_forwarding_rules = options[:port_forwarding_rules]  unless options[:port_forwarding_rules].nil?
+      end
+    end
   end
 end

--- a/functional-tests/networking/rsync_spec.rb
+++ b/functional-tests/networking/rsync_spec.rb
@@ -1,6 +1,9 @@
 describe 'Networking features' do
   it 'creates firewall and portwarding rules' do
-    expect(`vagrant up`).to include('Machine is booted and ready for use!')
+    expect(`vagrant up`).to include(
+      'box1: Machine is booted and ready for use!',
+      'box2: Machine is booted and ready for use!'
+    )
     expect($?.exitstatus).to eq(0)
 
     expect(`vagrant destroy --force`).to include('Terminating the instance...')

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -32,6 +32,8 @@ module VagrantPlugins
           # Get the configs
           @domain_config = @env[:machine].provider_config.get_domain_config(@domain)
 
+          sanitize_domain_config
+
           @zone             = CloudstackResource.new(@domain_config.zone_id, @domain_config.zone_name, 'zone')
           @network          = CloudstackResource.new(@domain_config.network_id, @domain_config.network_name, 'network')
           @service_offering = CloudstackResource.new(@domain_config.service_offering_id, @domain_config.service_offering_name, 'service_offering')
@@ -114,6 +116,11 @@ module VagrantPlugins
           terminate if @env[:interrupted]
 
           @app.call(@env)
+        end
+
+        def sanitize_domain_config
+          # Accept a single entry as input, convert it to array
+          @domain_config.pf_trusted_networks = [@domain_config.pf_trusted_networks] if @domain_config.pf_trusted_networks
         end
 
         def configure_networking


### PR DESCRIPTION
Has advantages of #113 while also keeping configfiles (Vagrant, Test-Kitchen) backward compatible.
