### PR TITLE
Support multiple network ids and network names

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `instance_ready_timeout` - The number of seconds to wait for the instance
   to become "ready" in Cloudstack. Defaults to 120 seconds.
 * `domain_id` - Domain id to launch the instance into
-* `network_id` - Network uuid that the instance should use
+* `network_id` - Network uuid(s) that the instance should use
+  - `network_id` is single value (e.g. `"AAAA"`) or multiple values (e.g. `["AAAA", "BBBB"]`)
 * `network_name` - Network name that the instance should use
 * `project_id` - Project uuid that the instance should belong to
 * `service_offering_id`- Service offering uuid to use for the instance

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `domain_id` - Domain id to launch the instance into
 * `network_id` - Network uuid(s) that the instance should use
   - `network_id` is single value (e.g. `"AAAA"`) or multiple values (e.g. `["AAAA", "BBBB"]`)
-* `network_name` - Network name that the instance should use
+* `network_name` - Network name(s) that the instance should use
+  - `network_name` is single value (e.g. `"AAAA"`) or multiple values (e.g. `["AAAA", "BBBB"]`)
 * `project_id` - Project uuid that the instance should belong to
 * `service_offering_id`- Service offering uuid to use for the instance
 * `service_offering_name`- Service offering name to use for the instance

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -34,22 +34,8 @@ module VagrantPlugins
 
           sanitize_domain_config
 
-          network_ids =
-            if @domain_config.network_id.nil?
-              []
-            else
-              Array(@domain_config.network_id)
-            end
-
-          network_names =
-            if @domain_config.network_name.nil?
-              []
-            else
-              Array(@domain_config.network_name)
-            end
-
           @zone             = CloudstackResource.new(@domain_config.zone_id, @domain_config.zone_name, 'zone')
-          @networks         = CloudstackResource.create_list(network_ids, network_names, 'network')
+          @networks         = CloudstackResource.create_list(@domain_config.network_id, @domain_config.network_name, 'network')
           @service_offering = CloudstackResource.new(@domain_config.service_offering_id, @domain_config.service_offering_name, 'service_offering')
           @disk_offering    = CloudstackResource.new(@domain_config.disk_offering_id, @domain_config.disk_offering_name, 'disk_offering')
           @template         = CloudstackResource.new(@domain_config.template_id, @domain_config.template_name || @env[:machine].config.vm.box, 'template')
@@ -139,6 +125,21 @@ module VagrantPlugins
         def sanitize_domain_config
           # Accept a single entry as input, convert it to array
           @domain_config.pf_trusted_networks = [@domain_config.pf_trusted_networks] if @domain_config.pf_trusted_networks
+
+          if @domain_config.network_id.nil?
+            # Use names if ids are not present
+            @domain_config.network_id = []
+
+            if @domain_config.network_name.nil?
+              @domain_config.network_name = []
+            else
+              @domain_config.network_name = Array(@domain_config.network_name)
+            end
+          else
+            # Use ids if present
+            @domain_config.network_id = Array(@domain_config.network_id)
+            @domain_config.network_name = []
+          end
         end
 
         def configure_networking

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -49,9 +49,9 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :domain_id
 
-      # Network uuid that the instance should use
+      # Network uuid(s) that the instance should use
       #
-      # @return [String]
+      # @return [String,Array]
       attr_accessor :network_id
 
       # Network name that the instance should use

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -54,9 +54,9 @@ module VagrantPlugins
       # @return [String,Array]
       attr_accessor :network_id
 
-      # Network name that the instance should use
+      # Network name(s) that the instance should use
       #
-      # @return [String]
+      # @return [String,Array]
       attr_accessor :network_name
 
       # Network Type

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -29,25 +29,21 @@ module VagrantPlugins
         end
 
         def self.create_list(ids, names, kind)
-          # padding with nil elements
-          if ids.length < names.length
-            ids += [nil] * (names.length - ids.length)
-          elsif ids.length > names.length
-            names += [nil] * (ids.length - names.length)
+          return create_id_list(ids, kind)     unless ids.empty?
+          return create_name_list(names, kind) unless names.empty?
+          []
+        end
+
+        def self.create_id_list(ids, kind)
+          ids.each_with_object([]) do |id, resources|
+            resources << CloudstackResource.new(id, nil, kind)
           end
+        end
 
-          ids_enum = ids.to_enum
-          names_enum = names.to_enum
-
-          resources = []
-
-          loop do
-            id = ids_enum.next
-            name = names_enum.next
-            resources << CloudstackResource.new(id, name, kind)
+        def self.create_name_list(names, kind)
+          names.each_with_object([]) do |name, resources|
+            resources << CloudstackResource.new(nil, name, kind)
           end
-
-          resources
         end
       end
     end

--- a/lib/vagrant-cloudstack/model/cloudstack_resource.rb
+++ b/lib/vagrant-cloudstack/model/cloudstack_resource.rb
@@ -27,6 +27,28 @@ module VagrantPlugins
         def to_s
           "#{kind} - #{id || '<unknown id>'}:#{name || '<unknown name>'}"
         end
+
+        def self.create_list(ids, names, kind)
+          # padding with nil elements
+          if ids.length < names.length
+            ids += [nil] * (names.length - ids.length)
+          elsif ids.length > names.length
+            names += [nil] * (ids.length - names.length)
+          end
+
+          ids_enum = ids.to_enum
+          names_enum = names.to_enum
+
+          resources = []
+
+          loop do
+            id = ids_enum.next
+            name = names_enum.next
+            resources << CloudstackResource.new(id, name, kind)
+          end
+
+          resources
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,7 @@ require 'simplecov'
 require 'coveralls'
 require 'rspec/its'
 
+Dir["#{__dir__}/vagrant-cloudstack/support/**/*.rb"].each { |f| require f }
+
 SimpleCov.start
 Coveralls.wear!

--- a/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
@@ -71,38 +71,25 @@ describe CloudstackResource do
     it { expect(CloudstackResource.new('', 'name', 'kind').is_name_undefined?).to be_eql false }
   end
 
-  describe '#create_list' do
-    subject { CloudstackResource.create_list(ids, names, kind) }
+  describe '#create_id_list' do
+    subject { CloudstackResource.create_id_list(ids, kind) }
 
     let(:kind) { 'network' }
+    let(:ids)  { %w(id1 id2) }
 
-    context 'When ids count == names count' do
-      let(:ids)   { %w(id1 id2) }
-      let(:names) { %w(name1 name2) }
+    its(:count) { should eq 2 }
+    its([0])    { should be_a_resource('id1', nil, kind) }
+    its([1])    { should be_a_resource('id2', nil, kind) }
+  end
 
-      its(:count) { should eq 2 }
-      its([0])    { should be_a_resource('id1', 'name1', kind) }
-      its([1])    { should be_a_resource('id2', 'name2', kind) }
-    end
+  describe '#create_name_list' do
+    subject { CloudstackResource.create_name_list(names, kind) }
 
-    context 'When ids count >= names count' do
-      let(:ids)   { %w(id1 id2 id3) }
-      let(:names) { %w(name1 name2) }
+    let(:kind)  { 'network' }
+    let(:names) { %w(name1 name2) }
 
-      its(:count) { should eq 3 }
-      its([0])    { should be_a_resource('id1', 'name1', kind) }
-      its([1])    { should be_a_resource('id2', 'name2', kind) }
-      its([2])    { should be_a_resource('id3', nil, kind) }
-    end
-
-    context 'When ids count <= names count' do
-      let(:ids)   { %w(id1 id2) }
-      let(:names) { %w(name1 name2 name3) }
-
-      its(:count) { should eq 3 }
-      its([0])    { should be_a_resource('id1', 'name1', kind) }
-      its([1])    { should be_a_resource('id2', 'name2', kind) }
-      its([2])    { should be_a_resource(nil, 'name3', kind) }
-    end
+    its(:count) { should eq 2 }
+    its([0])    { should be_a_resource(nil, 'name1', kind) }
+    its([1])    { should be_a_resource(nil, 'name2', kind) }
   end
 end

--- a/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
+++ b/spec/vagrant-cloudstack/model/cloudstack_resource_spec.rb
@@ -70,4 +70,39 @@ describe CloudstackResource do
     it { expect(CloudstackResource.new(nil, 'name', 'kind').is_name_undefined?).to be_eql false }
     it { expect(CloudstackResource.new('', 'name', 'kind').is_name_undefined?).to be_eql false }
   end
+
+  describe '#create_list' do
+    subject { CloudstackResource.create_list(ids, names, kind) }
+
+    let(:kind) { 'network' }
+
+    context 'When ids count == names count' do
+      let(:ids)   { %w(id1 id2) }
+      let(:names) { %w(name1 name2) }
+
+      its(:count) { should eq 2 }
+      its([0])    { should be_a_resource('id1', 'name1', kind) }
+      its([1])    { should be_a_resource('id2', 'name2', kind) }
+    end
+
+    context 'When ids count >= names count' do
+      let(:ids)   { %w(id1 id2 id3) }
+      let(:names) { %w(name1 name2) }
+
+      its(:count) { should eq 3 }
+      its([0])    { should be_a_resource('id1', 'name1', kind) }
+      its([1])    { should be_a_resource('id2', 'name2', kind) }
+      its([2])    { should be_a_resource('id3', nil, kind) }
+    end
+
+    context 'When ids count <= names count' do
+      let(:ids)   { %w(id1 id2) }
+      let(:names) { %w(name1 name2 name3) }
+
+      its(:count) { should eq 3 }
+      its([0])    { should be_a_resource('id1', 'name1', kind) }
+      its([1])    { should be_a_resource('id2', 'name2', kind) }
+      its([2])    { should be_a_resource(nil, 'name3', kind) }
+    end
+  end
 end

--- a/spec/vagrant-cloudstack/support/be_a_resource.rb
+++ b/spec/vagrant-cloudstack/support/be_a_resource.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :be_a_resource do |id, name, kind|
+  match do |actual|
+    actual.is_a?(VagrantPlugins::Cloudstack::Model::CloudstackResource) &&
+      actual.id == id && actual.name == name && actual.kind == kind
+  end
+end


### PR DESCRIPTION
CloudStack `network_ids` can accept multiple values. But vagrant-cloudstack plugin can not use multiple network_ids (only single network_id).

So I added feature for multiple network ids
# Usage

Vagrantfile

``` ruby
Vagrant.configure(2) do |config|
  config.vm.provider :cloudstack do |cloudstack, override|
    # single network id
    cloudstack.network_id = "AAAAA"

    # multiple network ids
    cloudstack.network_id = ["AAA", "BBB"]
  end
end
```
