### PR TITLE
Add ssh_network_id and ssh_network_name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `ssh_key` - Path to a private key to be used with ssh _(defaults to Vagrant's `config.ssh.private_key_path`)_
 * `ssh_user` - User name to be used with ssh _(defaults to Vagrant's `config.ssh.username`)_
 * `ssh_network_id` - The network_id to be used when loging in to the vm via ssh _(defaults to first nic)_
+* `ssh_network_name` - The network_name to be used when loging in to the vm via ssh _(defaults to first nic)_
+  - Use either `ssh_network_id` or `ssh_network_name`. If specified both , use `ssh_network_id`
 * `vm_user` - User name to be used with winrm _(defaults to Vagrant's `config.winrm.username`)_
 * `vm_password` - Password to be used with winrm. _(If the CloudStack template is "Password Enabled", leaving this unset will trigger the plugin to retrieve and use it.)_
 * `private_ip_address` - private (static)ip address to be used by the virtual machine

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `group` - Group for the instance
 * `ssh_key` - Path to a private key to be used with ssh _(defaults to Vagrant's `config.ssh.private_key_path`)_
 * `ssh_user` - User name to be used with ssh _(defaults to Vagrant's `config.ssh.username`)_
+* `ssh_network_id` - The network_id to be used when loging in to the vm via ssh _(defaults to first nic)_
 * `vm_user` - User name to be used with winrm _(defaults to Vagrant's `config.winrm.username`)_
 * `vm_password` - Password to be used with winrm. _(If the CloudStack template is "Password Enabled", leaving this unset will trigger the plugin to retrieve and use it.)_
 * `private_ip_address` - private (static)ip address to be used by the virtual machine

--- a/lib/vagrant-cloudstack/action/read_ssh_info.rb
+++ b/lib/vagrant-cloudstack/action/read_ssh_info.rb
@@ -70,8 +70,16 @@ module VagrantPlugins
             end
           end
 
+          nic_ip_address = server.nics[0]['ipaddress']
+
+          unless domain_config.ssh_network_id.nil?
+            # When ssh_network_id is specified, use the IP address that is linked to the network_id of nic
+            ssh_nic = server.nics.find { |nic| nic["networkid"] == domain_config.ssh_network_id }
+            nic_ip_address = ssh_nic["ipaddress"] if ssh_nic
+          end
+
           ssh_info = {
-                       :host => pf_ip_address || server.nics[0]['ipaddress'],
+                       :host => pf_ip_address || nic_ip_address,
                        :port => pf_public_port
                      }
           ssh_info = ssh_info.merge({

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -294,6 +294,7 @@ module VagrantPlugins
         @ssh_key                   = UNSET_VALUE
         @ssh_user                  = UNSET_VALUE
         @ssh_network_id            = UNSET_VALUE
+        @ssh_network_name          = UNSET_VALUE
         @vm_user                   = UNSET_VALUE
         @vm_password               = UNSET_VALUE
         @private_ip_address        = UNSET_VALUE

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -227,6 +227,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :ssh_network_id
 
+      # The network_name to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_network_name
+
       # The username to be used when loging in to the vm
       #
       # @return [String]
@@ -485,6 +490,9 @@ module VagrantPlugins
 
         # ssh network_id is nil by default
         @ssh_network_id         = nil if @ssh_network_id == UNSET_VALUE
+
+        # ssh network_name is nil by default
+        @ssh_network_name       = nil if @ssh_network_name == UNSET_VALUE
 
         # vm user is nil by default
         @vm_user               = nil if @vm_user == UNSET_VALUE

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -222,6 +222,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :ssh_user
 
+      # The network_id to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_network_id
+
       # The username to be used when loging in to the vm
       #
       # @return [String]
@@ -283,6 +288,7 @@ module VagrantPlugins
         @user_data                 = UNSET_VALUE
         @ssh_key                   = UNSET_VALUE
         @ssh_user                  = UNSET_VALUE
+        @ssh_network_id            = UNSET_VALUE
         @vm_user                   = UNSET_VALUE
         @vm_password               = UNSET_VALUE
         @private_ip_address        = UNSET_VALUE
@@ -476,6 +482,9 @@ module VagrantPlugins
 
         # ssh user is nil by default
         @ssh_user               = nil if @ssh_user == UNSET_VALUE
+
+        # ssh network_id is nil by default
+        @ssh_network_id         = nil if @ssh_network_id == UNSET_VALUE
 
         # vm user is nil by default
         @vm_user               = nil if @vm_user == UNSET_VALUE

--- a/spec/vagrant-cloudstack/action/read_ssh_info_spec.rb
+++ b/spec/vagrant-cloudstack/action/read_ssh_info_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+require 'vagrant-cloudstack/action/read_ssh_info'
+require 'vagrant-cloudstack/config'
+
+describe VagrantPlugins::Cloudstack::Action::ReadSSHInfo do
+  let(:action) { VagrantPlugins::Cloudstack::Action::ReadSSHInfo.new(nil, nil) }
+
+  describe "#fetch_nic_ip_address" do
+    subject { action.fetch_nic_ip_address(nics, domain_config) }
+
+    let(:nics) do
+      [
+        { "networkid" => "networkid1", "networkname" => "networkname1", "ipaddress" => "127.0.0.1" },
+        { "networkid" => "networkid2", "networkname" => "networkname2", "ipaddress" => "127.0.0.2" },
+        { "networkid" => "networkid3", "networkname" => "networkname3", "ipaddress" => "127.0.0.3" },
+      ]
+    end
+
+    let(:ssh_network_id)   { Vagrant::Plugin::V2::Config::UNSET_VALUE }
+    let(:ssh_network_name) { Vagrant::Plugin::V2::Config::UNSET_VALUE }
+
+    let(:domain_config) do
+      config = VagrantPlugins::Cloudstack::Config.new
+      config.domain_config :cloudstack do |cloudstack|
+        cloudstack.ssh_network_id   = ssh_network_id
+        cloudstack.ssh_network_name = ssh_network_name
+      end
+      config.finalize!
+      config.get_domain_config(:cloudstack)
+    end
+
+    context "without neither ssh_network_id and ssh_network_name" do
+      it { should eq "127.0.0.1" }
+    end
+
+    context "with ssh_network_id" do
+      context "when exists in nics" do
+        let(:ssh_network_id) { "networkid2" }
+
+        it { should eq "127.0.0.2" }
+      end
+
+      context "when not exists in nics" do
+        let(:ssh_network_id) { "unknown" }
+
+        it { should eq "127.0.0.1" }
+      end
+    end
+
+    context "with ssh_network_id" do
+      context "when exists in nics" do
+        let(:ssh_network_name) { "networkname3" }
+
+        it { should eq "127.0.0.3" }
+      end
+
+      context "when not exists in nics" do
+        let(:ssh_network_name) { "unknown" }
+
+        it { should eq "127.0.0.1" }
+      end
+    end
+
+    context "with both ssh_network_id and ssh_network_name" do
+      context "when exists in nics" do
+        let(:ssh_network_id)   { "networkid2" }
+        let(:ssh_network_name) { "networkname3" }
+
+        it { should eq "127.0.0.2" }
+      end
+
+      context "when not exists in nics" do
+        let(:ssh_network_id)   { "unknown" }
+        let(:ssh_network_name) { "unknown" }
+
+        it { should eq "127.0.0.1" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
I use multiple NICs, and ssh connection NIC is 2nd (eth1). But this plugin doesn't support except 1st NIC :cry:

So I added configuration `ssh_network_id`
# Usage

Vagrantfile

``` ruby
Vagrant.configure(2) do |config|
  config.vm.provider :cloudstack do |cloudstack, override|
    # NOTE: this feature is https://github.com/schubergphilis/vagrant-cloudstack/pull/148
    cloudstack.network_id = ["AAA", "BBB"]

    cloudstack.ssh_network_id = "BBB"
  end
end
```
