### PR TITLE
Fix user dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:functionaltest) do |t|
   t.pattern = "*_spec.rb"
   t.rspec_opts = "-fd"
+  t.verbose = false
 end
 
 # Immediately sync all stdout so that tools like buildbot can

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -182,7 +182,7 @@ module VagrantPlugins
         end
 
         def generate_display_name
-          local_user = ENV['USER'].dup
+          local_user = ENV['USER'] ? ENV['USER'].dup : 'VACS'
           local_user.gsub!(/[^-a-z0-9_]/i, '')
           prefix = @env[:root_path].basename.to_s
           prefix.gsub!(/[^-a-z0-9_]/i, '')


### PR DESCRIPTION
Fixes #157 

```
➜  vagrant-cloudstack git:(fix/user_dependency) ✗ bundle exec rake functional_tests:all                        
Running RSpec tests in folder : vmlifecycle
Using Vagrant file            : Vagrantfile.advanced_networking

VM Life Cycle
  starts Linux and Windows VM
  destroys Linux and Windows VM

Finished in 2 minutes 33.5 seconds (files took 0.12979 seconds to load)
2 examples, 0 failures

Running RSpec tests in folder : networking
Using Vagrant file            : Vagrantfile.advanced_networking

Networking features
  creates firewall and portwarding rules for both Virtual Router and VPC

Finished in 4 minutes 53.3 seconds (files took 0.08951 seconds to load)
1 example, 0 failures

Running RSpec tests in folder : rsync
Using Vagrant file            : Vagrantfile.advanced_networking

VM RSync
Connection to xx.xxx.xxx.xxx closed.
  does rsync to the VM

Finished in 1 minute 9 seconds (files took 0.10459 seconds to load)
1 example, 0 failures
```
