### PR TITLE
Prepare release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.4.0 (Nov 30, 2016)
+* Support multiple network ids and network names (PR #148)
+* Add ssh_network_id and ssh_network_name configuration (PR #149)
+* Add (firewall management for) VPC support (PR #151)
+* Remove additional data disk on destroy (PR #152)
+* Add Docker containers for development and testing (PR #159)
+* CloudStack >= 4.6 list all offerings / templates. (PR #161)
+
 # 1.3.0 (Mar 24, 2016)
 * Automate port forwarding for RDP for Windows guests (PR #117)
 * Specify `trusted_networks` by Array (PR #121)

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=1.3.0
+VERSION=1.4.0
 mkdir -p /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION
 cp -r . /tmp/vagrant-cloudstack-build_rpm.$$/vagrant-cloudstack-$VERSION/
 tar -C /tmp/vagrant-cloudstack-build_rpm.$$/ -czf ~/rpmbuild/SOURCES/vagrant-cloudstack-$VERSION.tar.gz vagrant-cloudstack-$VERSION

--- a/lib/vagrant-cloudstack/version.rb
+++ b/lib/vagrant-cloudstack/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Cloudstack
-    VERSION = '1.3.0'
+    VERSION = '1.4.0'
   end
 end


### PR DESCRIPTION
Preparing release 1.4.0. See CHANGELOG for details. Minor PRs excluded from CHANGELOG.

As this makes no functional/code change, testing is not required, still did to be sure:
```
➜  vagrant-cloudstack git:(release/v1.4.0) ✗ bundle exec rake functional_tests:all
Running RSpec tests in folder : vmlifecycle
Using Vagrant file            : Vagrantfile.advanced_networking

VM Life Cycle
  starts Linux and Windows VM
  destroys Linux and Windows VM

Finished in 2 minutes 52.3 seconds (files took 0.27769 seconds to load)
2 examples, 0 failures

Running RSpec tests in folder : networking
Using Vagrant file            : Vagrantfile.advanced_networking

Networking features
  creates firewall and portwarding rules for both Virtual Router and VPC

Finished in 5 minutes 8 seconds (files took 0.08303 seconds to load)
1 example, 0 failures

Running RSpec tests in folder : rsync
Using Vagrant file            : Vagrantfile.advanced_networking

VM RSync
Connection to 85.222.237.253 closed.
  does rsync to the VM

Finished in 1 minute 13.01 seconds (files took 0.08713 seconds to load)
1 example, 0 failures
``` 
