### PR TITLE
Don't set network_ids when using basic networking

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -241,7 +241,10 @@ module VagrantPlugins
                 :image_id => @template.id
             }
 
-            options['network_ids'] = @networks.map(&:id).compact.join(",") unless @networks.empty?
+            unless @networks.empty?
+              nets = @networks.map(&:id).compact.join(",")
+              options['network_ids'] = nets unless nets.empty?
+            end
             options['security_group_ids'] = @security_groups.map{|security_group| security_group.id}.join(',') unless @security_groups.empty?
             options['project_id'] = @domain_config.project_id unless @domain_config.project_id.nil?
             options['key_name'] = @domain_config.keypair unless @domain_config.keypair.nil?


### PR DESCRIPTION
In version 1.4.0, when using basic networking `@networks` is set to `CloudstackResource.new(nil, nil, 'network')` on [this line](https://github.com/MissionCriticalCloud/vagrant-cloudstack/blob/master/lib/vagrant-cloudstack/action/run_instance.rb#L54), so `@networks` is never empty.

In this case `@networks.map(&:id).compact.join(",")` as used on [this line](https://github.com/MissionCriticalCloud/vagrant-cloudstack/blob/master/lib/vagrant-cloudstack/action/run_instance.rb#L244) results in an empty string.

This causes the deployVirtualMachine API request to include `"networkids"        => ""` which makes CloudStack throw the error `Can't specify network Ids in Basic zone`.
