### PR TITLE
Update (development) Vagrant to 1.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .bundle
 pkg/*
 tags
-Gemfile.lock
 
 # Vagrant
 .vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y bsdtar
   - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.10.6
+  - rvm @global do gem install bundler -v 1.12.5
 rvm:
-  - 2.0.0
+  - 2.3
 script: rake
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - rvm @global do gem install bundler -v 1.12.5
 rvm:
   - 2.3
-script: rake
+script: bundle exec rake
 notifications:
   webhooks:
     urls:

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,14 +3,11 @@ FROM debian:8
 MAINTAINER Bob van den Heuvel <bvandenheuvel@schubergphilis.com>
 
 # Specific older chef-dk required due to bundler version, only available as Debian 6 package
-ENV	CHEFDK_VERSION 0.10.0
-ENV	CHEFDK_DEB_VERSION 6
+ENV	CHEFDK_VERSION 1.2.22
+ENV	CHEFDK_DEB_VERSION 8
 
 # Currently the latest version of the plugin has been tested with Vagrant 1.8.1
-ENV	VAGRANT_VERSION 1.8.1
-
-# The plugin currently depends on existence of the USER variable...
-ENV USER VAC
+ENV	VAGRANT_VERSION 1.9.1
 
 # Update before all package installations
 RUN apt-get update -y && \

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -75,17 +75,18 @@ _Note on usage of SSH keyfile_: As the container is mounted on a specific folder
 Development of the plugin, means running Vagrant from source, in combination with the specific bundler version (conflict) between ChefDK and Vagrant and ruby version (conflict) between ChefDK and Vagrant, leads to the following version combination:
 
 "dev" container:
-* Vagrant 1.8.1
-* ChefDK 0.10.0
-
-### ChefDK
+* Vagrant 1.9.1
+* ChefDK 1.2.22
+### latest_dependencies
 Based on (somewhat subjective :) experience, the latest version of ChefDK is mostly compatible, is used as latest version.
 
-"latest_dependensies" container:
+"latest_dependencies" container:
+* Vagrant 1.8.1
 * ChefDK 0.19
-
+### ChefDK
 For convenience of some reported incompatibilities, a separate container is defined:
 "chefdk_0_17" container:
+* Vagrant 1.8.1
 * ChefDK 0.17
 
 ### Kitchen-Vagrant plugin

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.8.1'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.9.1'
   gem 'coveralls', require: false
   gem 'simplecov', require: false
   gem 'rspec-core'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,299 @@
+GIT
+  remote: git://github.com/mitchellh/vagrant.git
+  revision: d8c2b2e5ababcdecc65b62b91e5dec21a4bc2d96
+  tag: v1.9.1
+  specs:
+    vagrant (1.9.1)
+      childprocess (~> 0.5.0)
+      erubis (~> 2.7.0)
+      hashicorp-checkpoint (~> 0.1.1)
+      i18n (>= 0.6.0, <= 0.8.0)
+      listen (~> 3.1.5)
+      log4r (~> 1.1.9, < 1.1.11)
+      net-scp (~> 1.1.0)
+      net-sftp (~> 2.1)
+      net-ssh (~> 3.0.1)
+      nokogiri (= 1.6.7.1)
+      rb-kqueue (~> 0.2.0)
+      rest-client (>= 1.6.0, < 3.0)
+      ruby_dep (<= 1.3.1)
+      wdm (~> 0.1.0)
+      winrm (~> 1.6)
+      winrm-fs (~> 0.3.0)
+
+PATH
+  remote: .
+  specs:
+    vagrant-cloudstack (1.4.0)
+      fog (>= 1.32.0)
+      fog-xml (>= 0.1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.5)
+    builder (3.2.3)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
+    coveralls (0.8.19)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    domain_name (0.5.20170223)
+      unf (>= 0.0.5, < 1.0.0)
+    erubis (2.7.0)
+    excon (0.55.0)
+    ffi (1.9.18)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.40.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.43)
+      fog-digitalocean (>= 0.3.0)
+      fog-dnsimple (~> 1.0)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      json (>= 1.8, < 2.0)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (1.2.1)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.11.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-digitalocean (0.3.0)
+      fog-core (~> 1.42)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.5)
+    fog-dnsimple (1.0.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-openstack (0.1.20)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-rackspace (0.1.4)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (1.8.0)
+      fog-core
+      rbvmomi (~> 1.9)
+    fog-xenserver (0.3.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    hashicorp-checkpoint (0.1.4)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    httpclient (2.8.3)
+    i18n (0.8.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.3)
+    json (1.8.6)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    little-plugger (1.1.4)
+    log4r (1.1.10)
+    logging (2.2.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.0.0)
+    multi_json (1.12.1)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.2)
+    netrc (0.11.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+    nori (2.6.0)
+    rake (10.5.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.4)
+      ffi (>= 0.5.0)
+    rbvmomi (1.10.0)
+      builder (~> 3.0)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      trollop (~> 2.1)
+    rest-client (2.0.1)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    ruby_dep (1.3.1)
+    rubyntlm (0.6.1)
+    rubyzip (1.2.1)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    term-ansicolor (1.4.0)
+      tins (~> 1.0)
+    thor (0.19.4)
+    tins (1.13.2)
+    trollop (2.1.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    wdm (0.1.1)
+    winrm (1.8.1)
+      builder (>= 2.1.2)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0)
+    winrm-fs (0.3.2)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 1.5)
+    xml-simple (1.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  coveralls
+  rake (~> 10.5, >= 10.4)
+  rspec-core
+  rspec-expectations
+  rspec-its
+  rspec-mocks
+  simplecov
+  vagrant!
+  vagrant-cloudstack!
+
+BUNDLED WITH
+   1.12.5

--- a/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
+++ b/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
@@ -26,6 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
       config.vm.box = options['template']
 
       config.vm.communicator = options['communicator']
+      config.winrm.retry_delay = 30
       config.vm.synced_folder ".", "/vagrant", type: "rsync",
         rsync__exclude: [".git/", "vendor"], disabled: options['rsync_disabled']
       config.vm.provider :cloudstack do |cloudstack, override|

--- a/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
+++ b/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
@@ -53,14 +53,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
         cloudstack.pf_trusted_networks   = ENV['SOURCE_CIDR']
         cloudstack.pf_open_firewall      = false
 
-        unless ENV['SSH_KEY'].nil?
-            cloudstack.ssh_key               = ENV['SSH_KEY']
-            cloudstack.ssh_user              = ENV['SSH_USER']
-        end
 
-        unless ENV['WINDOWS_USER'].nil?
-            cloudstack.vm_user = ENV['WINDOWS_USER']
-        end
+        cloudstack.ssh_key               = ENV['SSH_KEY'] unless ENV['SSH_KEY'].nil?
+        cloudstack.ssh_user              = ENV['SSH_USER'] unless ENV['SSH_USER'].nil?
+        cloudstack.vm_user               = ENV['WINDOWS_USER'] unless ENV['WINDOWS_USER'].nil?
+
       end
     end
   end

--- a/spec/vagrant-cloudstack/config_spec.rb
+++ b/spec/vagrant-cloudstack/config_spec.rb
@@ -6,7 +6,7 @@ describe VagrantPlugins::Cloudstack::Config do
 
   # Ensure tests are not affected by Cloudstack credential environment variables
   before :each do
-    ENV.stub(:[] => nil)
+    allow(ENV).to receive_messages(:[] => nil)
   end
 
   describe "defaults" do
@@ -71,8 +71,8 @@ describe VagrantPlugins::Cloudstack::Config do
 
     context "with CloudStack credential variables" do
       before :each do
-        ENV.stub(:[]).with("CLOUDSTACK_API_KEY").and_return("api_key")
-        ENV.stub(:[]).with("CLOUDSTACK_SECRET_KEY").and_return("secret_key")
+        allow(ENV).to receive(:[]).with("CLOUDSTACK_API_KEY").and_return("api_key")
+        allow(ENV).to receive(:[]).with("CLOUDSTACK_SECRET_KEY").and_return("secret_key")
       end
 
       subject do
@@ -98,7 +98,7 @@ describe VagrantPlugins::Cloudstack::Config do
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")
         instance.finalize!
-        instance.send(attribute).should == "foo"
+        expect(instance.send(attribute)).to be =='foo'
       end
 
     end
@@ -107,7 +107,7 @@ describe VagrantPlugins::Cloudstack::Config do
       instance.pf_open_firewall = false
       instance.finalize!
 
-      instance.pf_open_firewall.should == false
+      expect(instance.pf_open_firewall).to be false
     end
   end
 
@@ -208,7 +208,7 @@ describe VagrantPlugins::Cloudstack::Config do
 
     it "should raise an exception if not finalized" do
       expect { instance.get_domain_config("default") }.
-        to raise_error
+        to raise_error(RuntimeError)
     end
 
     context "with no specific config set" do

--- a/vagrant-cloudstack.gemspec
+++ b/vagrant-cloudstack.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'vagrant-cloudstack'
 
-  s.add_runtime_dependency 'fog', '~> 1.32', '>= 1.32.0'
+  s.add_runtime_dependency 'fog', '>= 1.32.0'
+  s.add_runtime_dependency 'fog-xml', '>= 0.1.2'
 
   s.add_development_dependency 'rake',                '>= 10.4', '~> 10.5'
   s.add_development_dependency 'rspec-core',          '~> 2.14', '>= 2.14.7'


### PR DESCRIPTION
The development environment (mine :wink: and Docker container) is based on ChefDK. Using version 1.2.22, there are no blocking dependencies (mostly bundler) with (fairly) latest version of Vagrant (1.9.1)


Considering the limited number of people doing PR validation, please aprove the latest PR in this change (see also #170), which will effectively aprove all PRs.
