### PR TITLE
Add cloudstack option root_disk_size

### DIFF
--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -233,6 +233,7 @@ module VagrantPlugins
           @env[:ui].info(" -- Display Name: #{@domain_config.display_name}")
           @env[:ui].info(" -- Group: #{@domain_config.group}") if @domain_config.group
           @env[:ui].info(" -- Service offering: #{@service_offering.name} (#{@service_offering.id})")
+          @env[:ui].info(" -- Root disk size: #{@domain_config.root_disk_size}G") unless @domain_config.root_disk_size.nil?
           @env[:ui].info(" -- Disk offering: #{@disk_offering.name} (#{@disk_offering.id})") unless @disk_offering.id.nil?
           @env[:ui].info(" -- Template: #{@template.name} (#{@template.id})")
           @env[:ui].info(" -- Project UUID: #{@domain_config.project_id}") unless @domain_config.project_id.nil?
@@ -289,6 +290,7 @@ module VagrantPlugins
           options['name'] = @domain_config.name unless @domain_config.name.nil?
           options['ip_address'] = @domain_config.private_ip_address unless @domain_config.private_ip_address.nil?
           options['disk_offering_id'] = @disk_offering.id unless @disk_offering.id.nil?
+          options['root_disk_size'] = @domain_config.root_disk_size unless @domain_config.root_disk_size.nil?
 
           if @domain_config.user_data != nil
             options['user_data'] = Base64.urlsafe_encode64(@domain_config.user_data)

--- a/lib/vagrant-cloudstack/config.rb
+++ b/lib/vagrant-cloudstack/config.rb
@@ -3,11 +3,16 @@ require "vagrant"
 module VagrantPlugins
   module Cloudstack
     class Config < Vagrant.plugin("2", :config)
-      INSTANCE_VAR_DEFAULT_NIL = %w(host name path port domain_id network_id network_name project_id service_offering_id service_offering_name
-           template_id template_name zone_id zone_name keypair pf_ip_address_id pf_ip_address pf_public_port
-           pf_public_rdp_port pf_private_port pf_trusted_networks display_name group user_data ssh_key ssh_user
-           ssh_network_id ssh_network_name vm_user vm_password private_ip_address).freeze
-      INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules firewall_rules security_group_ids security_group_names security_groups).freeze
+      INSTANCE_VAR_DEFAULT_NIL = %w(host name path port domain_id network_id
+       network_name project_id service_offering_id service_offering_name
+       template_id template_name root_disk_size zone_id zone_name keypair
+       pf_ip_address_id pf_ip_address pf_public_port pf_public_rdp_port
+       pf_private_port pf_trusted_networks display_name group user_data
+       ssh_key ssh_user ssh_network_id ssh_network_name vm_user vm_password
+       private_ip_address).freeze
+      INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules
+       firewall_rules security_group_ids security_group_names
+       security_groups).freeze
 
       # Cloudstack api host.
       #
@@ -104,6 +109,11 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :template_name
+
+      # Size of the rootdisk in Gigabyte
+      #
+      # @return [Fixnum]
+      attr_accessor :root_disk_size
 
       # Zone uuid to launch the instance into. If nil, it will
       # launch in default project.


### PR DESCRIPTION
Starting with fog 2.1.0 root_disk_size is supported for cloudstack. This
allows templates that support it to grow the root-fs on inital create.