### PR TITLE
Fix new VM password lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Fixed bugs:
+
+- `store_passwd` would sometimes try to lookup an async job status without including the job id causing an exception being raised
+
 # 1.5.1 (18 Apr 2019)
 
 **Implemented enhancements:**

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -253,6 +253,7 @@ module VagrantPlugins
             options = compose_server_creation_options
 
             @server = @env[:cloudstack_compute].servers.create(options)
+            @server_job_id = @server.job_id
           rescue Fog::Compute::Cloudstack::NotFound => e
             # Invalid subnet doesn't have its own error so we catch and
             # check the error message here.
@@ -759,14 +760,14 @@ module VagrantPlugins
         def store_password
           password = nil
           if @server.password_enabled and @server.respond_to?('job_id')
-            server_job_result = @env[:cloudstack_compute].query_async_job_result({:jobid => @server.job_id})
+            server_job_result = @env[:cloudstack_compute].query_async_job_result({:jobid => @server_job_id})
             if server_job_result.nil?
               @env[:ui].warn(' -- Failed to retrieve job_result for retrieving the password')
               return
             end
 
             while true
-              server_job_result = @env[:cloudstack_compute].query_async_job_result({:jobid => @server.job_id})
+              server_job_result = @env[:cloudstack_compute].query_async_job_result({:jobid => @server_job_id})
               if server_job_result['queryasyncjobresultresponse']['jobstatus'] != 0
                 password = server_job_result['queryasyncjobresultresponse']['jobresult']['virtualmachine']['password']
                 break

--- a/spec/vagrant-cloudstack/action/run_instance_spec.rb
+++ b/spec/vagrant-cloudstack/action/run_instance_spec.rb
@@ -260,6 +260,7 @@ describe VagrantPlugins::Cloudstack::Action::RunInstance do
 
       allow(machine).to receive(:provider_config).and_return(provider_config)
       expect(server).to receive(:wait_for).and_return(ready = true)
+      allow(server).to receive(:job_id).and_return(JOB_ID)
       allow(server).to receive(:password_enabled).and_return(false)
       expect(cloudstack_compute).to receive(:servers).and_return(servers)
       allow(cloudstack_compute).to receive(:send).with(:list_zones, available: true, name: ZONE_NAME).and_return(list_zones_response)


### PR DESCRIPTION
Sometimes `store_password` would do a `query_async_job_result` with an
empty job id. This is because `@server` would be updated using fog's
`list_virtual_machines` which returns an empty jobid field once the
deploy job has completed.

This commit fixes that by saving the deploy job id to a variable
to be used by `store_password`

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>